### PR TITLE
flytta widgets runt på spegel & spara i mongodb

### DIFF
--- a/backend/DashyBoard.Api/Controllers/MirrorController.cs
+++ b/backend/DashyBoard.Api/Controllers/MirrorController.cs
@@ -1,4 +1,5 @@
 ﻿using DashyBoard.Application.Commands.Mirror;
+using DashyBoard.Application.Commands.Widget;
 using DashyBoard.Application.Queries.Mirror;
 using DashyBoard.Application.Queries.Mirror.Dto;
 using MediatR;
@@ -73,4 +74,32 @@ public class MirrorController : ControllerBase
         await _mediator.Send(new DeleteMirrorCommand(id), ct);
         return NoContent();
     }
+
+    [HttpPost("{mirrorId:guid}/widget")]
+    [ProducesResponseType(typeof(MirrorDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> AddWidget(Guid mirrorId, [FromBody] AddWidgetRequest request, CancellationToken ct)
+    {
+        var result = await _mediator.Send(new AddWidgetCommand(mirrorId, request.Type, request.X, request.Y), ct);
+        return Ok(result);
+    }
+
+    [HttpPut("{mirrorId:guid}/widget/{widgetId:guid}")]
+    [ProducesResponseType(typeof(MirrorDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> MoveWidget(Guid mirrorId, Guid widgetId, [FromBody] MoveWidgetRequest request, CancellationToken ct)
+    {
+        var result = await _mediator.Send(new MoveWidgetCommand(mirrorId, widgetId, request.X, request.Y), ct);
+        return Ok(result);
+    }
+
+    [HttpDelete("{mirrorId:guid}/widget/{widgetId:guid}")]
+    [ProducesResponseType(typeof(MirrorDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> RemoveWidget(Guid mirrorId, Guid widgetId, CancellationToken ct)
+    {
+        var result = await _mediator.Send(new RemoveWidgetCommand(mirrorId, widgetId), ct);
+        return Ok(result);
+    }
 }
+
+public record CreateMirrorRequest(string Name, double WidthCm, double HeightCm);
+public record AddWidgetRequest(string Type, double X, double Y);
+public record MoveWidgetRequest(double X, double Y);

--- a/backend/DashyBoard.Application/Commands/Widget/AddWidgetCommand.cs
+++ b/backend/DashyBoard.Application/Commands/Widget/AddWidgetCommand.cs
@@ -1,0 +1,10 @@
+﻿using DashyBoard.Application.Queries.Mirror.Dto;
+using MediatR;
+
+namespace DashyBoard.Application.Commands.Widget;
+
+public sealed record AddWidgetCommand(
+    Guid MirrorId, 
+    string Type, 
+    double X, 
+    double Y) : IRequest<MirrorDto>;

--- a/backend/DashyBoard.Application/Commands/Widget/AddWidgetCommandHandler.cs
+++ b/backend/DashyBoard.Application/Commands/Widget/AddWidgetCommandHandler.cs
@@ -1,0 +1,25 @@
+﻿using DashyBoard.Application.Interfaces;
+using DashyBoard.Application.Queries.Mirror.Dto;
+using MediatR;
+
+namespace DashyBoard.Application.Commands.Widget;
+
+internal class AddWidgetCommandHandler : IRequestHandler<AddWidgetCommand, MirrorDto>
+{
+    private readonly IMirrorRepository _mirrorRepository;
+
+    public AddWidgetCommandHandler(IMirrorRepository mirrorRepository)
+    {
+        _mirrorRepository = mirrorRepository;
+    }
+
+    public async Task<MirrorDto> Handle(AddWidgetCommand request, CancellationToken cancellationToken)
+    {
+        return await _mirrorRepository.AddWidgetAsync(
+            request.MirrorId,
+            request.Type,
+            request.X,
+            request.Y,
+            cancellationToken);
+    }
+}

--- a/backend/DashyBoard.Application/Commands/Widget/MoveWidgetCommand.cs
+++ b/backend/DashyBoard.Application/Commands/Widget/MoveWidgetCommand.cs
@@ -1,0 +1,10 @@
+﻿using DashyBoard.Application.Queries.Mirror.Dto;
+using MediatR;
+
+namespace DashyBoard.Application.Commands.Widget;
+
+public sealed record MoveWidgetCommand(
+    Guid MirrorId, 
+    Guid WidgetId, 
+    double X, 
+    double Y) : IRequest<MirrorDto>;

--- a/backend/DashyBoard.Application/Commands/Widget/MoveWidgetCommandHandler.cs
+++ b/backend/DashyBoard.Application/Commands/Widget/MoveWidgetCommandHandler.cs
@@ -1,0 +1,25 @@
+﻿using DashyBoard.Application.Interfaces;
+using DashyBoard.Application.Queries.Mirror.Dto;
+using MediatR;
+
+namespace DashyBoard.Application.Commands.Widget;
+
+internal class MoveWidgetCommandHandler : IRequestHandler<MoveWidgetCommand, MirrorDto>
+{
+    private readonly IMirrorRepository _mirrorRepository;
+
+    public MoveWidgetCommandHandler(IMirrorRepository mirrorRepository)
+    {
+        _mirrorRepository = mirrorRepository;
+    }
+
+    public async Task<MirrorDto> Handle(MoveWidgetCommand request, CancellationToken cancellationToken)
+    {
+        return await _mirrorRepository.MoveWidgetAsync(
+            request.MirrorId, 
+            request.WidgetId, 
+            request.X, 
+            request.Y, 
+            cancellationToken);
+    }
+}

--- a/backend/DashyBoard.Application/Commands/Widget/RemoveWidgetCommand.cs
+++ b/backend/DashyBoard.Application/Commands/Widget/RemoveWidgetCommand.cs
@@ -1,0 +1,8 @@
+﻿using DashyBoard.Application.Queries.Mirror.Dto;
+using MediatR;
+
+namespace DashyBoard.Application.Commands.Widget;
+
+public sealed record RemoveWidgetCommand(
+    Guid MirrorId,
+    Guid WidgetId) : IRequest<MirrorDto>;

--- a/backend/DashyBoard.Application/Commands/Widget/RemoveWidgetCommandHandler.cs
+++ b/backend/DashyBoard.Application/Commands/Widget/RemoveWidgetCommandHandler.cs
@@ -1,0 +1,23 @@
+﻿using DashyBoard.Application.Interfaces;
+using DashyBoard.Application.Queries.Mirror.Dto;
+using MediatR;
+
+namespace DashyBoard.Application.Commands.Widget;
+
+internal class RemoveWidgetCommandHandler : IRequestHandler<RemoveWidgetCommand, MirrorDto>
+{
+    private readonly IMirrorRepository _mirrorRepository;
+
+    public RemoveWidgetCommandHandler(IMirrorRepository mirrorRepository)
+    {
+        _mirrorRepository = mirrorRepository;
+    }
+
+    public async Task<MirrorDto> Handle(RemoveWidgetCommand request, CancellationToken cancellationToken)
+    {
+        return await _mirrorRepository.RemoveWidgetAsync(
+            request.MirrorId, 
+            request.WidgetId, 
+            cancellationToken);
+    }
+}

--- a/backend/DashyBoard.Application/Interfaces/IMirrorRepository.cs
+++ b/backend/DashyBoard.Application/Interfaces/IMirrorRepository.cs
@@ -9,4 +9,9 @@ public interface IMirrorRepository
     Task<MirrorDto> CreateMirrorAsync(string userSub, string name, double widthCm, double heightCm, CancellationToken ct);
     Task<MirrorDto> UpdateMirrorAsync(Guid id, string name, double widthCm, double heightCm, CancellationToken ct);
     Task DeleteMirrorAsync(Guid id, CancellationToken ct);
+
+    Task<MirrorDto> AddWidgetAsync(Guid mirrorId, string type, double x, double y, CancellationToken ct);
+    Task<MirrorDto> MoveWidgetAsync(Guid mirrorId, Guid widgetId, double x, double y, CancellationToken ct);
+    Task<MirrorDto> RemoveWidgetAsync(Guid mirrorId, Guid widgetId, CancellationToken ct);
+
 }

--- a/backend/DashyBoard.Application/Queries/Mirror/Dto/MirrorDto.cs
+++ b/backend/DashyBoard.Application/Queries/Mirror/Dto/MirrorDto.cs
@@ -8,4 +8,13 @@ public sealed record MirrorDto
     public double WidthCm { get; set; }
     public double HeightCm { get; set; }
     public DateTime CreatedAt { get; set; }
+    public List<WidgetDto> Widgets { get; set; } = new();
+}
+
+public sealed class WidgetDto
+{
+    public Guid Id { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public double X { get; set; }
+    public double Y { get; set; }
 }

--- a/backend/DashyBoard.Domain/Models/Mirror.cs
+++ b/backend/DashyBoard.Domain/Models/Mirror.cs
@@ -8,6 +8,8 @@ public class Mirror
     public double HeightCm { get; private set; }
     public DateTime CreatedAt { get; private set; }
 
+    public List<Widget> Widgets { get; private set; } = new();
+
     private Mirror() { }
 
     public Mirror(string userSub, string name, double widthCm, double heightCm)
@@ -25,5 +27,30 @@ public class Mirror
         Name = name;
         WidthCm = widthCm;
         HeightCm = heightCm;
+    }
+
+    public void AddWidget(string type, double x, double y)
+    {
+        Widgets.Add(new Widget(type, x, y));
+    }
+
+    public void RemoveWidget(Guid widgetId)
+    {
+        var widget = Widgets.FirstOrDefault(w => w.Id == widgetId);
+
+        if (widget is null)
+            throw new KeyNotFoundException($"Widget with id {widgetId} not found.");
+
+        Widgets.Remove(widget);
+    }
+
+    public void MoveWidget(Guid widgetId, double x, double y)
+    {
+        var widget = Widgets.FirstOrDefault(w => w.Id == widgetId);
+
+        if (widget is null)
+            throw new KeyNotFoundException($"Widget with id {widgetId} not found.");
+
+        widget.Move(x, y);
     }
 }

--- a/backend/DashyBoard.Domain/Models/Widget.cs
+++ b/backend/DashyBoard.Domain/Models/Widget.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DashyBoard.Domain.Models
+{
+    public sealed class Widget
+    {
+        public Guid Id { get; private set; }
+        public string Type { get; private set; } = string.Empty;
+        public double X { get; private set; }
+        public double Y { get; private set; }
+
+        public Widget(string type, double x, double y)
+        {
+            Id = Guid.NewGuid();
+            Type = type;
+            X = x;
+            Y = y;
+        }
+
+        public void Move(double x, double y)
+        {
+            X = x;
+            Y = y;
+        }
+    }
+}

--- a/backend/DashyBoard.Infrastructure/Configuration/MongoDbConfigurator.cs
+++ b/backend/DashyBoard.Infrastructure/Configuration/MongoDbConfigurator.cs
@@ -17,5 +17,14 @@ public static class MongoDbConfigurator
                 cm.MapIdMember(m => m.Id).SetSerializer(new GuidSerializer(BsonType.String));
             });
         }
+
+        if (!BsonClassMap.IsClassMapRegistered(typeof(Widget)))
+        {
+            BsonClassMap.RegisterClassMap<Widget>(cm =>
+            {
+                cm.AutoMap();
+                cm.MapIdMember(w => w.Id).SetSerializer(new GuidSerializer(BsonType.String));
+            });
+        }
     }
 }

--- a/backend/DashyBoard.Infrastructure/Repositories/MirrorRepository.cs
+++ b/backend/DashyBoard.Infrastructure/Repositories/MirrorRepository.cs
@@ -59,6 +59,48 @@ public sealed class MirrorRepository : IMirrorRepository
             throw new KeyNotFoundException($"Mirror with id {id} not found.");
     }
 
+    public async Task<MirrorDto> AddWidgetAsync(Guid mirrorId, string type, double x, double y, CancellationToken ct)
+    {
+        var mirror = await _collection
+            .Find(m => m.Id == mirrorId)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Mirror with id {mirrorId} not found.");
+
+        mirror.AddWidget(type, x, y);
+
+        await _collection.ReplaceOneAsync(m => m.Id == mirrorId, mirror, cancellationToken: ct);
+
+        return MapToDto(mirror);
+    }
+
+    public async Task<MirrorDto> MoveWidgetAsync(Guid mirrorId, Guid widgetId, double x, double y, CancellationToken ct)
+    {
+        var mirror = await _collection
+            .Find(m => m.Id == mirrorId)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Mirror with id {mirrorId} not found.");
+
+        mirror.MoveWidget(widgetId, x, y);
+
+        await _collection.ReplaceOneAsync(m => m.Id == mirrorId, mirror, cancellationToken: ct);
+
+        return MapToDto(mirror);
+    }
+
+    public async Task<MirrorDto> RemoveWidgetAsync(Guid mirrorId, Guid widgetId, CancellationToken ct)
+    {
+        var mirror = await _collection
+            .Find(m => m.Id == mirrorId)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Mirror with id {mirrorId} not found.");
+
+        mirror.RemoveWidget(widgetId);
+
+        await _collection.ReplaceOneAsync(m => m.Id == mirrorId, mirror, cancellationToken: ct);
+
+        return MapToDto(mirror);
+    }
+
     private static MirrorDto MapToDto(Mirror mirror) => new()
     {
         Id = mirror.Id,
@@ -67,5 +109,14 @@ public sealed class MirrorRepository : IMirrorRepository
         WidthCm = mirror.WidthCm,
         HeightCm = mirror.HeightCm,
         CreatedAt = mirror.CreatedAt,
+        Widgets = mirror.Widgets.Select(MapWidgetToDto).ToList()
+    };
+
+    private static WidgetDto MapWidgetToDto(Widget widget) => new()
+    {
+        Id = widget.Id,
+        Type = widget.Type,
+        X = widget.X,
+        Y = widget.Y
     };
 }

--- a/frontend/src/api/endpoints/mirror.ts
+++ b/frontend/src/api/endpoints/mirror.ts
@@ -1,5 +1,6 @@
 import { api } from '../apiSlice';
-import type { MirrorDto, CreateMirrorRequest, UpdateMirrorRequest } from '../types/mirror';
+import type { MirrorDto, CreateMirrorRequest, UpdateMirrorRequest,   AddWidgetRequest,
+  MoveWidgetRequest, } from '../types/mirror';
 
 const mirrorApi = api.injectEndpoints({
   endpoints: (builder) => ({
@@ -26,6 +27,49 @@ const mirrorApi = api.injectEndpoints({
       query: (id) => ({ url: `/mirror/${id}`, method: 'DELETE' }),
       invalidatesTags: [{ type: 'Mirror', id: 'LIST' }],
     }),
+     addWidget: builder.mutation<
+      MirrorDto,
+      { mirrorId: string; body: AddWidgetRequest }
+    >({
+      query: ({ mirrorId, body }) => ({
+        url: `/mirror/${mirrorId}/widget`,
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: (_result, _error, { mirrorId }) => [
+        { type: 'Mirror', id: mirrorId },
+        { type: 'Mirror', id: 'LIST' },
+      ],
+    }),
+
+    moveWidget: builder.mutation<
+      MirrorDto,
+      { mirrorId: string; widgetId: string; body: MoveWidgetRequest }
+    >({
+      query: ({ mirrorId, widgetId, body }) => ({
+        url: `/mirror/${mirrorId}/widget/${widgetId}`,
+        method: 'PUT',
+        body,
+      }),
+      invalidatesTags: (_result, _error, { mirrorId }) => [
+        { type: 'Mirror', id: mirrorId },
+        { type: 'Mirror', id: 'LIST' },
+      ],
+    }),
+
+    removeWidget: builder.mutation<
+      MirrorDto,
+      { mirrorId: string; widgetId: string }
+    >({
+      query: ({ mirrorId, widgetId }) => ({
+        url: `/mirror/${mirrorId}/widget/${widgetId}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (_result, _error, { mirrorId }) => [
+        { type: 'Mirror', id: mirrorId },
+        { type: 'Mirror', id: 'LIST' },
+      ],
+    }),
   }),
 });
 
@@ -35,4 +79,7 @@ export const {
   useCreateMirrorMutation,
   useUpdateMirrorMutation,
   useDeleteMirrorMutation,
+  useAddWidgetMutation,
+  useMoveWidgetMutation,
+  useRemoveWidgetMutation,
 } = mirrorApi;

--- a/frontend/src/api/types/mirror.ts
+++ b/frontend/src/api/types/mirror.ts
@@ -1,3 +1,10 @@
+export interface WidgetDto {
+  id: string;
+  type: string;
+  x: number;
+  y: number;
+}
+
 export interface MirrorDto {
   id: string;
   userSub: string;
@@ -5,6 +12,7 @@ export interface MirrorDto {
   widthCm: number;
   heightCm: number;
   createdAt: string;
+  widgets: WidgetDto[];
 }
 
 export interface CreateMirrorRequest {
@@ -17,4 +25,15 @@ export interface UpdateMirrorRequest {
   name: string;
   widthCm: number;
   heightCm: number;
+}
+
+export interface AddWidgetRequest {
+  type: string;
+  x: number;
+  y: number;
+}
+
+export interface MoveWidgetRequest {
+  x: number;
+  y: number;
 }

--- a/frontend/src/components/layout/editMode/EditModeToggle.tsx
+++ b/frontend/src/components/layout/editMode/EditModeToggle.tsx
@@ -3,9 +3,20 @@ import { useEditModeContext } from '../../../context/EditModeContext';
 
 interface EditModeToggleProps {
   disabled?: boolean;
+  /** Called instead of context enterEditMode when provided */
+  onEnterEditMode?: () => void;
+  /** Called instead of context saveEditMode when provided */
+  onSave?: () => void | Promise<void>;
+  /** Called instead of context discardEditMode when provided */
+  onDiscard?: () => void;
 }
 
-export function EditModeToggle({ disabled = false }: EditModeToggleProps) {
+export function EditModeToggle({
+  disabled = false,
+  onEnterEditMode,
+  onSave,
+  onDiscard,
+}: EditModeToggleProps) {
   const { isEditMode, enterEditMode, saveEditMode, discardEditMode, toggleSidebar } =
     useEditModeContext();
 
@@ -24,13 +35,13 @@ export function EditModeToggle({ disabled = false }: EditModeToggleProps) {
         {/* Save / Discard bottom-right */}
         <div className="fixed bottom-6 right-6 z-50 flex items-center gap-2 animate-in fade-in slide-in-from-bottom-4 duration-300">
           <button
-            onClick={discardEditMode}
+            onClick={onDiscard ?? discardEditMode}
             className="px-4 py-2 rounded-full text-sm font-medium border border-border bg-surface text-foreground-secondary hover:text-foreground hover:bg-overlay transition-all cursor-pointer"
           >
             Discard
           </button>
           <button
-            onClick={saveEditMode}
+            onClick={onSave ?? saveEditMode}
             className="px-4 py-2 rounded-full text-sm font-medium bg-primary text-white hover:bg-primary-hover transition-all cursor-pointer shadow-lg"
           >
             Save
@@ -42,7 +53,7 @@ export function EditModeToggle({ disabled = false }: EditModeToggleProps) {
 
   return (
     <button
-      onClick={enterEditMode}
+      onClick={onEnterEditMode ?? enterEditMode}
       disabled={disabled}
       aria-label="Enter edit mode"
       className="fixed bottom-6 right-6 z-50 w-12 h-12 rounded-full bg-surface border border-border text-muted hover:text-foreground hover:border-primary hover:shadow-[0_0_0_3px_rgba(51,153,255,0.15)] transition-all duration-200 flex items-center justify-center cursor-pointer group disabled:opacity-40 disabled:pointer-events-none"

--- a/frontend/src/components/mirrors/MirrorCanvas.tsx
+++ b/frontend/src/components/mirrors/MirrorCanvas.tsx
@@ -1,37 +1,93 @@
+import { useCallback, useMemo } from 'react';
 import { useEditModeContext } from '../../context/EditModeContext';
 import { useMirrorScale } from '../../hooks/useMirrorScale';
+import { useWidgetDrag } from '../../hooks/useWidgetDrag';
 import { MirrorGrid } from './MirrorGrid';
 import type { MirrorDto } from '../../api/types/mirror';
-import type { WidgetType } from '../layout/dashboard/widgetSidebar/types.ts';
 import { widgetRegistry } from '../widgets/widgetRegistry';
 
 interface MirrorCanvasProps {
   mirror: MirrorDto | null;
-  widgets: WidgetType[];
-  onRemoveWidget: (widget: WidgetType) => void;
+  onRemoveWidget: (widgetId: string) => void;
+  onMoveWidget: (widgetId: string, x: number, y: number) => Promise<void> | void;
 }
 
-export const MirrorCanvas = ({ mirror, widgets, onRemoveWidget }: MirrorCanvasProps) => {
+export const MirrorCanvas = ({
+  mirror,
+  onRemoveWidget,
+  onMoveWidget,
+}: MirrorCanvasProps) => {
   const { isEditMode } = useEditModeContext();
   const { containerRef, scale, canvasWidth, canvasHeight } = useMirrorScale(
     mirror?.widthCm ?? 0,
     mirror?.heightCm ?? 0,
   );
 
-  const renderedWidgets = widgets
+  const memoizedOnMoveWidget = useCallback(
+    (widgetId: string, x: number, y: number) => {
+      onMoveWidget(widgetId, x, y);
+    },
+    [onMoveWidget],
+  );
+
+  const memoizedOnRemoveWidget = useCallback(
+    (widgetId: string) => {
+      onRemoveWidget(widgetId);
+    },
+    [onRemoveWidget],
+  );
+
+
+  const widgets = useMemo(() => mirror?.widgets ?? [], [mirror]);
+
+  const { canvasRef, handlePointerDown, handlePointerMove, handlePointerUp, getWidgetPosition } =
+    useWidgetDrag({
+      canvasWidth,
+      canvasHeight,
+      widgets,
+      isEditMode,
+      onSaveWidgetPosition: memoizedOnMoveWidget,
+    });
+
+  if (!mirror) {
+    return (
+      <div
+        ref={containerRef}
+        className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 overflow-hidden p-8"
+      >
+        <p className="text-sm text-muted">Select a mirror to start editing</p>
+      </div>
+    );
+  }
+
+  const renderedWidgets = mirror.widgets
     .map((widget) => {
-      const definition = widgetRegistry.find((w) => w.id === widget);
+      const definition = widgetRegistry.find((w) => w.id === widget.type);
 
       if (!definition) return null;
 
       const WidgetComponent = definition.component;
+      const position = getWidgetPosition(widget.id, widget.x, widget.y);
+
       return (
-        <div key={widget} className="relative group">
-          <WidgetComponent />
+        <div
+          key={widget.id}
+          data-widget-id={widget.id}
+          className={`absolute group touch-none ${isEditMode ? 'cursor-grab active:cursor-grabbing' : ''}`}
+          style={{
+            left: position.x,
+            top: position.y,
+          }}
+          onPointerDown={
+            isEditMode
+              ? (event) => handlePointerDown(event, widget.id, position.x, position.y)
+              : undefined
+          }
+        >
           {isEditMode && (
             <button
               type="button"
-              onClick={() => onRemoveWidget(widget)}
+              onClick={() => memoizedOnRemoveWidget(widget.id)}
               aria-label={`Ta bort ${definition.name}`}
               className="absolute -top-2 -right-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-white opacity-0 shadow group-hover:opacity-100 transition-opacity"
             >
@@ -40,21 +96,14 @@ export const MirrorCanvas = ({ mirror, widgets, onRemoveWidget }: MirrorCanvasPr
               </svg>
             </button>
           )}
+
+          <WidgetComponent />
         </div>
       );
     })
     .filter(Boolean);
 
-  if (!mirror) {
-    return (
-      <div
-        ref={containerRef}
-        className="flex-1 flex flex-col items-center justify-center gap-3 overflow-hidden p-8 min-h-0"
-      >
-        <p className="text-muted text-sm">Select a mirror to start editing</p>
-      </div>
-    );
-  }
+
 
   return (
     <div
@@ -62,12 +111,16 @@ export const MirrorCanvas = ({ mirror, widgets, onRemoveWidget }: MirrorCanvasPr
       className="flex-1 flex flex-col items-center justify-center gap-3 overflow-hidden p-8"
     >
       <div
+        ref={canvasRef}
         style={{ width: canvasWidth, height: canvasHeight }}
         className={`relative transition-all duration-300 rounded ${
           isEditMode
             ? 'ring-2 ring-primary outline-dashed outline-2 -outline-offset-2 outline-primary/30 bg-surface/50'
             : 'border border-border bg-surface/30'
         }`}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerUp}
       >
         <MirrorGrid
           widthPx={canvasWidth}
@@ -78,8 +131,8 @@ export const MirrorCanvas = ({ mirror, widgets, onRemoveWidget }: MirrorCanvasPr
         />
 
         <div className="absolute top-3 left-3 flex flex-col gap-3">
-          {renderedWidgets}
-        </div>
+        {renderedWidgets}
+      </div>
       </div>
 
       <p className="text-xs text-muted">

--- a/frontend/src/components/widgets/ClockWidget.tsx
+++ b/frontend/src/components/widgets/ClockWidget.tsx
@@ -5,11 +5,13 @@ import { toZonedTime } from 'date-fns-tz';
 import { useClockTimezone } from '../../hooks/useClockTimezone';
 import { ClockTimezoneForm } from '../forms/ClockTimezoneForm';
 import { GlassCard } from '../ui/glass-card';
+import { useEditModeContext } from '../../context/EditModeContext';
 
 export function ClockWidget() {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [now, setNow] = useState(() => new Date());
   const { selectedTimezone, availableTimezones, handleTimezoneChange } = useClockTimezone();
+  const { isEditMode } = useEditModeContext();
 
   useEffect(() => {
     const timer = setInterval(() => setNow(new Date()), 1000);
@@ -22,15 +24,21 @@ export function ClockWidget() {
 
   return (
     <>
-      <GlassCard
-        className="glass-widget w-72 cursor-pointer"
-        onClick={() => setIsEditModalOpen(true)}
-      >
+      <GlassCard className="glass-widget w-72">
         <div className="space-y-2 text-center">
           <p className="text-5xl font-semibold text-foreground tracking-tight">{timeLabel}</p>
           <p className="text-foreground-secondary">{dateLabel}</p>
           <p className="text-small text-muted">{selectedTimezone.replace('_', ' ')}</p>
         </div>
+        {isEditMode && (
+          <button
+            type="button"
+            onClick={() => setIsEditModalOpen(true)}
+            className="mt-3 w-full rounded-md border border-border bg-overlay px-2 py-1 text-xs text-foreground-secondary transition hover:bg-glass"
+          >
+            Ändra tidszon
+          </button>
+        )}
       </GlassCard>
 
       {isEditModalOpen && (

--- a/frontend/src/components/widgets/ReminderWidget.tsx
+++ b/frontend/src/components/widgets/ReminderWidget.tsx
@@ -3,6 +3,7 @@ import { useGetRemindersQuery } from '../../api/endpoints/reminder';
 import type { ReminderDto } from '../../api/types/reminder';
 import { ReminderForm } from '../forms/ReminderForm';
 import { GlassCard } from '../ui/glass-card';
+import { useEditModeContext } from '../../context/EditModeContext';
 
 const dayLabelFormatter = new Intl.DateTimeFormat('sv-SE', { weekday: 'short', day: 'numeric', month: 'short' });
 const timeFormatter = new Intl.DateTimeFormat('sv-SE', { hour: '2-digit', minute: '2-digit' });
@@ -21,6 +22,7 @@ function sortUpcoming(reminders: ReminderDto[]): ReminderDto[] {
 export function ReminderWidget() {
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
     const { data: reminders = [], isLoading, isError } = useGetRemindersQuery();
+    const { isEditMode } = useEditModeContext();
 
     const upcoming = useMemo(() => sortUpcoming(reminders), [reminders]);
     const visibleReminders = upcoming.slice(0, 4);
@@ -36,13 +38,15 @@ export function ReminderWidget() {
                             <span className="rounded-full bg-overlay px-2 py-0.5 text-xs text-muted">
                                 {upcoming.length}
                             </span>
-                            <button
-                                type="button"
-                                onClick={() => setIsEditModalOpen(true)}
-                                className="rounded-md border border-border bg-overlay px-2 py-1 text-xs text-foreground-secondary transition hover:bg-glass"
-                            >
-                                Edit
-                            </button>
+                            {isEditMode && (
+                              <button
+                                  type="button"
+                                  onClick={() => setIsEditModalOpen(true)}
+                                  className="rounded-md border border-border bg-overlay px-2 py-1 text-xs text-foreground-secondary transition hover:bg-glass"
+                              >
+                                  Edit
+                              </button>
+                            )}
                         </div>
                     </div>
 

--- a/frontend/src/hooks/useWidgetDrag.ts
+++ b/frontend/src/hooks/useWidgetDrag.ts
@@ -1,0 +1,121 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface WidgetPosition {
+  id: string;
+  x: number;
+  y: number;
+}
+
+interface DragState {
+  widgetId: string;
+  offsetX: number;
+  offsetY: number;
+}
+
+interface UseWidgetDragProps {
+  canvasWidth: number;
+  canvasHeight: number;
+  widgets: WidgetPosition[];
+  isEditMode: boolean;
+  onSaveWidgetPosition: (widgetId: string, x: number, y: number) => Promise<void> | void;
+}
+
+export function useWidgetDrag({
+  canvasWidth,
+  canvasHeight,
+  widgets,
+  isEditMode,
+  onSaveWidgetPosition,
+}: UseWidgetDragProps) {
+  const canvasRef = useRef<HTMLDivElement | null>(null);
+  const [dragState, setDragState] = useState<DragState | null>(null);
+  const [localPositions, setLocalPositions] = useState<Record<string, { x: number; y: number }>>({});
+
+  useEffect(() => {
+    const nextPositions = widgets.reduce<Record<string, { x: number; y: number }>>((acc, widget) => {
+      acc[widget.id] = { x: widget.x, y: widget.y };
+      return acc;
+    }, {});
+
+    setLocalPositions(nextPositions);
+  }, [widgets]);
+
+  const clamp = (value: number, min: number, max: number) =>
+    Math.min(Math.max(value, min), max);
+
+  const handlePointerDown = (
+    event: React.PointerEvent<HTMLElement>,
+    widgetId: string,
+    widgetX: number,
+    widgetY: number,
+  ) => {
+    if (!isEditMode || !canvasRef.current) return;
+
+    // Don't start drag if the user clicked on an interactive element
+    const target = event.target as HTMLElement;
+    if (target.closest('button, a, input, select, textarea, [role="button"], [role="combobox"]')) return;
+
+    const rect = canvasRef.current.getBoundingClientRect();
+
+    const offsetX = event.clientX - rect.left - widgetX;
+    const offsetY = event.clientY - rect.top - widgetY;
+
+    setDragState({
+      widgetId,
+      offsetX,
+      offsetY,
+    });
+
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragState || !canvasRef.current) return;
+
+    const rect = canvasRef.current.getBoundingClientRect();
+
+    const rawX = event.clientX - rect.left - dragState.offsetX;
+    const rawY = event.clientY - rect.top - dragState.offsetY;
+
+    const widgetElement = canvasRef.current.querySelector(
+      `[data-widget-id="${dragState.widgetId}"]`,
+    ) as HTMLDivElement | null;
+
+    const widgetWidth = widgetElement?.offsetWidth ?? 200;
+    const widgetHeight = widgetElement?.offsetHeight ?? 100;
+
+    const nextX = clamp(rawX, 0, canvasWidth - widgetWidth);
+    const nextY = clamp(rawY, 0, canvasHeight - widgetHeight);
+
+    setLocalPositions((prev) => ({
+      ...prev,
+      [dragState.widgetId]: { x: nextX, y: nextY },
+    }));
+  };
+
+  const handlePointerUp = async () => {
+    if (!dragState) return;
+
+    const position = localPositions[dragState.widgetId];
+    const widgetId = dragState.widgetId;
+
+    setDragState(null);
+
+    if (!position) return;
+
+    await onSaveWidgetPosition(widgetId, position.x, position.y);
+  };
+
+  const getWidgetPosition = (widgetId: string, fallbackX: number, fallbackY: number) => {
+    return localPositions[widgetId] ?? { x: fallbackX, y: fallbackY };
+  };
+
+  return {
+    canvasRef,
+    dragState,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    getWidgetPosition,
+  };
+}

--- a/frontend/src/pages/Mirrors.tsx
+++ b/frontend/src/pages/Mirrors.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { WidgetSidebar } from '../components/layout/dashboard/WidgetSidebar';
 import { EditModeToggle } from '../components/layout/editMode/EditModeToggle';
 import { EditModeProvider, useEditModeContext } from '../context/EditModeContext';
@@ -17,42 +17,129 @@ import type { WidgetType } from '../components/layout/dashboard/widgetSidebar/ty
 import type { MirrorDto } from '../api/types/mirror';
 
 function MirrorContent() {
-  const { isEditMode } = useEditModeContext();
+  const { isEditMode, enterEditMode, saveEditMode, discardEditMode } = useEditModeContext();
   const [activeMirrorId, setActiveMirrorId] = useState<string | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingMirror, setEditingMirror] = useState<MirrorDto | null>(null);
   const [deletingMirror, setDeletingMirror] = useState<MirrorDto | null>(null);
 
-  const { data: mirrors = [] } = useGetMyMirrorsQuery();
+  // Local copy of the mirror used during edit mode – changes are buffered here
+  // and only flushed to the server when the user clicks "Save".
+  const [localMirror, setLocalMirror] = useState<MirrorDto | null>(null);
+  const snapshotRef = useRef<MirrorDto | null>(null);
+
+  const { data: mirrors = [], refetch: refetchMirrors } = useGetMyMirrorsQuery();
   const [addWidget] = useAddWidgetMutation();
   const [moveWidget] = useMoveWidgetMutation();
   const [removeWidget] = useRemoveWidgetMutation();
 
   const activeMirror = mirrors.find((m) => m.id === activeMirrorId) ?? null;
 
-  const handleAddWidget = useCallback(
-    (widget: WidgetType) => {
-      if (!activeMirrorId) return;
-      addWidget({ mirrorId: activeMirrorId, body: { type: widget, x: 0, y: 0 } });
-    },
-    [activeMirrorId, addWidget],
-  );
+  // The canvas always renders the local copy while in edit mode so that no API
+  // call is needed for instant feedback. In view mode it uses the server data.
+  // Show localMirror whenever it exists (including while background save mutations are in-flight)
+  const displayedMirror = localMirror ?? activeMirror;
 
-  const handleRemoveWidget = useCallback(
-    (widgetId: string) => {
-      if (!activeMirrorId) return;
-      removeWidget({ mirrorId: activeMirrorId, widgetId });
-    },
-    [activeMirrorId, removeWidget],
-  );
+  // Fallback: if edit mode was persisted via localStorage and the mirror data
+  // arrives after mount, initialise the local copy automatically.
+  useEffect(() => {
+    if (isEditMode && activeMirror && snapshotRef.current === null) {
+      const snapshot = structuredClone(activeMirror);
+      snapshotRef.current = snapshot;
+      setLocalMirror(structuredClone(activeMirror));
+    }
+  }, [isEditMode, activeMirror]);
 
-  const handleMoveWidget = useCallback(
-    (widgetId: string, x: number, y: number) => {
-      if (!activeMirrorId) return;
-      moveWidget({ mirrorId: activeMirrorId, widgetId, body: { x, y } });
-    },
-    [activeMirrorId, moveWidget],
-  );
+  const handleEnterEditMode = () => {
+    if (!activeMirror) return;
+    const snapshot = structuredClone(activeMirror);
+    snapshotRef.current = snapshot;
+    setLocalMirror(structuredClone(activeMirror));
+    enterEditMode();
+  };
+
+  // All widget mutations only update the local copy – no API calls yet.
+  const handleAddWidget = useCallback((widget: WidgetType) => {
+    const tempId = `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    setLocalMirror((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        widgets: [...prev.widgets, { id: tempId, type: widget, x: 0, y: 0 }],
+      };
+    });
+  }, []);
+
+  const handleRemoveWidget = useCallback((widgetId: string) => {
+    setLocalMirror((prev) => {
+      if (!prev) return prev;
+      return { ...prev, widgets: prev.widgets.filter((w) => w.id !== widgetId) };
+    });
+  }, []);
+
+  const handleMoveWidget = useCallback((widgetId: string, x: number, y: number) => {
+    setLocalMirror((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        widgets: prev.widgets.map((w) => (w.id === widgetId ? { ...w, x, y } : w)),
+      };
+    });
+  }, []);
+
+  // On Save: diff local state vs snapshot and flush only the changes.
+  const handleSave = useCallback(async () => {
+    const snapshot = snapshotRef.current;
+    if (!localMirror || !snapshot) {
+      saveEditMode();
+      return;
+    }
+
+    const mirrorId = localMirror.id;
+    const promises: Promise<unknown>[] = [];
+
+    // Widgets that were removed during the session
+    const removedIds = snapshot.widgets
+      .filter((sw) => !localMirror.widgets.find((cw) => cw.id === sw.id))
+      .map((sw) => sw.id);
+    for (const widgetId of removedIds) {
+      promises.push(removeWidget({ mirrorId, widgetId }).unwrap());
+    }
+
+    // Widgets that were added (identified by temp IDs)
+    for (const w of localMirror.widgets.filter((w) => w.id.startsWith('temp-'))) {
+      promises.push(addWidget({ mirrorId, body: { type: w.type, x: w.x, y: w.y } }).unwrap());
+    }
+
+    // Existing widgets whose position changed
+    for (const w of localMirror.widgets) {
+      if (w.id.startsWith('temp-')) continue;
+      const orig = snapshot.widgets.find((sw) => sw.id === w.id);
+      if (orig && (orig.x !== w.x || orig.y !== w.y)) {
+        promises.push(moveWidget({ mirrorId, widgetId: w.id, body: { x: w.x, y: w.y } }).unwrap());
+      }
+    }
+
+    // Exit edit mode immediately — no perceived lag for the user.
+    // localMirror stays set so displayedMirror keeps showing the correct state
+    // while mutations run in the background, then refetch so activeMirror is
+    // fresh before we clear localMirror (avoids the stale-data flicker).
+    saveEditMode();
+
+    Promise.all(promises)
+      .then(() => refetchMirrors())
+      .finally(() => {
+        setLocalMirror(null);
+        snapshotRef.current = null;
+      });
+  }, [localMirror, addWidget, removeWidget, moveWidget, saveEditMode, refetchMirrors]);
+
+  // On Discard: simply throw away the local copy – server state is untouched.
+  const handleDiscard = useCallback(() => {
+    setLocalMirror(null);
+    snapshotRef.current = null;
+    discardEditMode();
+  }, [discardEditMode]);
 
   const handleDeleted = () => {
     if (deletingMirror?.id === activeMirrorId) setActiveMirrorId(null);
@@ -86,11 +173,16 @@ function MirrorContent() {
           <WidgetSidebar onAddWidget={handleAddWidget} canAddWidget={Boolean(activeMirrorId)} />
         )}
         <MirrorCanvas
-          mirror={activeMirror}
+          mirror={displayedMirror}
           onRemoveWidget={handleRemoveWidget}
           onMoveWidget={handleMoveWidget}
         />
-        <EditModeToggle disabled={!activeMirror} />
+        <EditModeToggle
+          disabled={!activeMirror}
+          onEnterEditMode={handleEnterEditMode}
+          onSave={handleSave}
+          onDiscard={handleDiscard}
+        />
       </div>
     </div>
   );

--- a/frontend/src/pages/Mirrors.tsx
+++ b/frontend/src/pages/Mirrors.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { WidgetSidebar } from '../components/layout/dashboard/WidgetSidebar';
 import { EditModeToggle } from '../components/layout/editMode/EditModeToggle';
 import { EditModeProvider, useEditModeContext } from '../context/EditModeContext';
@@ -6,7 +6,12 @@ import { MirrorSubNav } from '../components/layout/navigation/sub-navigation/Mir
 import { CreateMirrorModal } from '../components/mirrors/CreateMirrorModal';
 import { EditMirrorModal } from '../components/mirrors/EditMirrorModal';
 import { DeleteMirrorModal } from '../components/mirrors/DeleteMirrorModal';
-import { useGetMyMirrorsQuery } from '../api/endpoints/mirror';
+import {
+  useGetMyMirrorsQuery,
+  useAddWidgetMutation,
+  useMoveWidgetMutation,
+  useRemoveWidgetMutation,
+} from '../api/endpoints/mirror';
 import { MirrorCanvas } from '../components/mirrors/MirrorCanvas';
 import type { WidgetType } from '../components/layout/dashboard/widgetSidebar/types.ts';
 import type { MirrorDto } from '../api/types/mirror';
@@ -15,38 +20,39 @@ function MirrorContent() {
   const { isEditMode } = useEditModeContext();
   const [activeMirrorId, setActiveMirrorId] = useState<string | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
-  const [widgetsByMirrorId, setWidgetsByMirrorId] = useState<Record<string, WidgetType[]>>({});
   const [editingMirror, setEditingMirror] = useState<MirrorDto | null>(null);
   const [deletingMirror, setDeletingMirror] = useState<MirrorDto | null>(null);
+
   const { data: mirrors = [] } = useGetMyMirrorsQuery();
+  const [addWidget] = useAddWidgetMutation();
+  const [moveWidget] = useMoveWidgetMutation();
+  const [removeWidget] = useRemoveWidgetMutation();
 
   const activeMirror = mirrors.find((m) => m.id === activeMirrorId) ?? null;
-  const activeWidgets = activeMirrorId ? (widgetsByMirrorId[activeMirrorId] ?? []) : [];
 
-  const handleAddWidget = (widget: WidgetType) => {
-    if (!activeMirrorId) return;
+  const handleAddWidget = useCallback(
+    (widget: WidgetType) => {
+      if (!activeMirrorId) return;
+      addWidget({ mirrorId: activeMirrorId, body: { type: widget, x: 0, y: 0 } });
+    },
+    [activeMirrorId, addWidget],
+  );
 
-    setWidgetsByMirrorId((prev) => {
-      const current = prev[activeMirrorId] ?? [];
+  const handleRemoveWidget = useCallback(
+    (widgetId: string) => {
+      if (!activeMirrorId) return;
+      removeWidget({ mirrorId: activeMirrorId, widgetId });
+    },
+    [activeMirrorId, removeWidget],
+  );
 
-      if (current.includes(widget)) {
-        return prev;
-      }
-
-      return {
-        ...prev,
-        [activeMirrorId]: [...current, widget],
-      };
-    });
-  };
-
-  const handleRemoveWidget = (widget: WidgetType) => {
-    if (!activeMirrorId) return;
-    setWidgetsByMirrorId((prev) => ({
-      ...prev,
-      [activeMirrorId]: (prev[activeMirrorId] ?? []).filter((w) => w !== widget),
-    }));
-  };
+  const handleMoveWidget = useCallback(
+    (widgetId: string, x: number, y: number) => {
+      if (!activeMirrorId) return;
+      moveWidget({ mirrorId: activeMirrorId, widgetId, body: { x, y } });
+    },
+    [activeMirrorId, moveWidget],
+  );
 
   const handleDeleted = () => {
     if (deletingMirror?.id === activeMirrorId) setActiveMirrorId(null);
@@ -81,8 +87,8 @@ function MirrorContent() {
         )}
         <MirrorCanvas
           mirror={activeMirror}
-          widgets={activeWidgets}
           onRemoveWidget={handleRemoveWidget}
+          onMoveWidget={handleMoveWidget}
         />
         <EditModeToggle disabled={!activeMirror} />
       </div>


### PR DESCRIPTION
**Utan redigeringsläget**
<img width="1222" height="673" alt="image" src="https://github.com/user-attachments/assets/ad98a2f6-f048-44ee-8030-7ea7677f8292" />

**Redigeringsläget** 
blir som en hand som greppar tag i widgeten som gör det möjligt att flytta runt dem knappar och annat som finns i widgeten går fortfarande att trycka på så att det är enkelt att redigera dem, knapparna för att redigera widgetarna finns numera bara i editmode :)

<img width="1439" height="790" alt="image" src="https://github.com/user-attachments/assets/331a817a-1894-4172-8971-11ef8eb5f029" />


## Checklista
* [x] Har du kontrollerat att PR-rubriken är beskrivande och att det är tydligt vilken US som PR kopplas till?
* [x] Har du kontrollerat att filändringarna speglar syftet med PR?
* [x] Har du testat din kod lokalt, om möjligt?
* [ ] Har du kört enhets- och integrationstester och att dessa inte failar?
* [ ] Har du skapat nya enhets- eller integrationstester, där det är nödvändigt?
* [x] Har du följt vår kodstandard?
* [ ] Om din kod innehåller migrations, har du testat så att dessa funkar?
* [ ] Har du uppdaterat dokumentation kopplat till PR, om nödvändigt?
