### PR TITLE
Create deploy-prod.yml

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,71 @@
+name: Deploy to Prod
+
+on:
+  push:
+    branches:
+      - prod
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore backend dependencies
+        run: dotnet restore ./backend/DashyBoard.slnx
+
+      - name: Build backend
+        run: dotnet build ./backend/DashyBoard.slnx --configuration Release --no-restore
+
+      - name: Run backend tests
+        run: dotnet test ./backend/DashyBoard.slnx --configuration Release --no-build
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ./frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: ./frontend
+        run: npm run build
+
+  deploy-prod:
+    name: Deploy to Render Prod
+    runs-on: ubuntu-latest
+    needs: build-and-test
+
+    environment:
+      name: Prod
+      url: https://www.dashyboard.se/
+
+    steps:
+      - name: Trigger Render frontend deploy
+        env:
+          RENDER_FRONTEND_DEPLOY_HOOK_URL: ${{ secrets.RENDER_FRONTEND_DEPLOY_HOOK_URL }}
+        run: |
+          curl --fail --silent --show-error --request POST "$RENDER_FRONTEND_DEPLOY_HOOK_URL"
+
+      - name: Trigger Render backend deploy
+        env:
+          RENDER_BACKEND_DEPLOY_HOOK_URL: ${{ secrets.RENDER_BACKEND_DEPLOY_HOOK_URL }}
+        run: |
+          curl --fail --silent --show-error --request POST "$RENDER_BACKEND_DEPLOY_HOOK_URL"


### PR DESCRIPTION
Tanken med detta är att prod blir en tydlig release-branch som representerar det som faktiskt ska ut till användaren
Samt att GitHub environmentet Prod kan användas för skydd, godkännanden och tydlig deployment-historik

för att detta ska funka behöver vi: 
- stäng av auto-deploy på Render för prod

## Checklista
* [ ] Har du kontrollerat att PR-rubriken är beskrivande och att det är tydligt vilken US som PR kopplas till?
* [ ] Har du kontrollerat att filändringarna speglar syftet med PR?
* [ ] Har du testat din kod lokalt, om möjligt?
* [ ] Har du kört enhets- och integrationstester och att dessa inte failar?
* [ ] Har du skapat nya enhets- eller integrationstester, där det är nödvändigt?
* [ ] Har du följt vår kodstandard?
* [ ] Om din kod innehåller migrations, har du testat så att dessa funkar?
* [ ] Har du uppdaterat dokumentation kopplat till PR, om nödvändigt?
