### PR TITLE
feat: implement mirror editor modals and hooks for managing mirror state

### DIFF
--- a/frontend/src/components/mirrors/MirrorEditorModals.tsx
+++ b/frontend/src/components/mirrors/MirrorEditorModals.tsx
@@ -10,7 +10,9 @@ interface MirrorEditorModalsProps {
   deletingMirror: MirrorDto | null;
   activeMirror: MirrorDto | null;
   pendingMirrorSwitch: MirrorDto | null;
+  pendingRouteLabel: string | null;
   isResolvingMirrorSwitch: boolean;
+  isResolvingRouteChange: boolean;
   onCloseCreateModal: () => void;
   onCloseEditModal: () => void;
   onCloseDeleteModal: () => void;
@@ -18,6 +20,9 @@ interface MirrorEditorModalsProps {
   onClosePendingMirrorSwitch: () => void;
   onDiscardAndSwitch: () => void;
   onSaveAndSwitch: () => void;
+  onClosePendingRoute: () => void;
+  onDiscardAndNavigate: () => void;
+  onSaveAndNavigate: () => void;
 }
 
 export function MirrorEditorModals({
@@ -26,7 +31,9 @@ export function MirrorEditorModals({
   deletingMirror,
   activeMirror,
   pendingMirrorSwitch,
+  pendingRouteLabel,
   isResolvingMirrorSwitch,
+  isResolvingRouteChange,
   onCloseCreateModal,
   onCloseEditModal,
   onCloseDeleteModal,
@@ -34,6 +41,9 @@ export function MirrorEditorModals({
   onClosePendingMirrorSwitch,
   onDiscardAndSwitch,
   onSaveAndSwitch,
+  onClosePendingRoute,
+  onDiscardAndNavigate,
+  onSaveAndNavigate,
 }: MirrorEditorModalsProps) {
   return (
     <>
@@ -49,11 +59,22 @@ export function MirrorEditorModals({
       {pendingMirrorSwitch && (
         <UnsavedMirrorChangesModal
           currentMirror={activeMirror}
-          nextMirror={pendingMirrorSwitch}
+          nextLabel={pendingMirrorSwitch.name}
           isSaving={isResolvingMirrorSwitch}
           onClose={onClosePendingMirrorSwitch}
           onDiscard={onDiscardAndSwitch}
           onSave={onSaveAndSwitch}
+        />
+      )}
+      {pendingRouteLabel && (
+        <UnsavedMirrorChangesModal
+          currentMirror={activeMirror}
+          nextLabel={pendingRouteLabel}
+          destinationType="page"
+          isSaving={isResolvingRouteChange}
+          onClose={onClosePendingRoute}
+          onDiscard={onDiscardAndNavigate}
+          onSave={onSaveAndNavigate}
         />
       )}
     </>

--- a/frontend/src/components/mirrors/MirrorEditorModals.tsx
+++ b/frontend/src/components/mirrors/MirrorEditorModals.tsx
@@ -1,0 +1,61 @@
+import type { MirrorDto } from '../../api/types/mirror';
+import { CreateMirrorModal } from './CreateMirrorModal';
+import { EditMirrorModal } from './EditMirrorModal';
+import { DeleteMirrorModal } from './DeleteMirrorModal';
+import { UnsavedMirrorChangesModal } from './UnsavedMirrorChangesModal';
+
+interface MirrorEditorModalsProps {
+  showCreateModal: boolean;
+  editingMirror: MirrorDto | null;
+  deletingMirror: MirrorDto | null;
+  activeMirror: MirrorDto | null;
+  pendingMirrorSwitch: MirrorDto | null;
+  isResolvingMirrorSwitch: boolean;
+  onCloseCreateModal: () => void;
+  onCloseEditModal: () => void;
+  onCloseDeleteModal: () => void;
+  onDeletedMirror: () => void;
+  onClosePendingMirrorSwitch: () => void;
+  onDiscardAndSwitch: () => void;
+  onSaveAndSwitch: () => void;
+}
+
+export function MirrorEditorModals({
+  showCreateModal,
+  editingMirror,
+  deletingMirror,
+  activeMirror,
+  pendingMirrorSwitch,
+  isResolvingMirrorSwitch,
+  onCloseCreateModal,
+  onCloseEditModal,
+  onCloseDeleteModal,
+  onDeletedMirror,
+  onClosePendingMirrorSwitch,
+  onDiscardAndSwitch,
+  onSaveAndSwitch,
+}: MirrorEditorModalsProps) {
+  return (
+    <>
+      {showCreateModal && <CreateMirrorModal onClose={onCloseCreateModal} />}
+      {editingMirror && <EditMirrorModal mirror={editingMirror} onClose={onCloseEditModal} />}
+      {deletingMirror && (
+        <DeleteMirrorModal
+          mirror={deletingMirror}
+          onClose={onCloseDeleteModal}
+          onDeleted={onDeletedMirror}
+        />
+      )}
+      {pendingMirrorSwitch && (
+        <UnsavedMirrorChangesModal
+          currentMirror={activeMirror}
+          nextMirror={pendingMirrorSwitch}
+          isSaving={isResolvingMirrorSwitch}
+          onClose={onClosePendingMirrorSwitch}
+          onDiscard={onDiscardAndSwitch}
+          onSave={onSaveAndSwitch}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/mirrors/UnsavedMirrorChangesModal.tsx
+++ b/frontend/src/components/mirrors/UnsavedMirrorChangesModal.tsx
@@ -3,7 +3,8 @@ import type { MirrorDto } from '../../api/types/mirror';
 
 interface UnsavedMirrorChangesModalProps {
   currentMirror: MirrorDto | null;
-  nextMirror: MirrorDto;
+  nextLabel: string;
+  destinationType?: 'mirror' | 'page';
   isSaving: boolean;
   onClose: () => void;
   onDiscard: () => void;
@@ -12,13 +13,23 @@ interface UnsavedMirrorChangesModalProps {
 
 export const UnsavedMirrorChangesModal = ({
   currentMirror,
-  nextMirror,
+  nextLabel,
+  destinationType = 'mirror',
   isSaving,
   onClose,
   onDiscard,
   onSave,
-}: UnsavedMirrorChangesModalProps) =>
-  createPortal(
+}: UnsavedMirrorChangesModalProps) => {
+  const isMirrorDestination = destinationType === 'mirror';
+  const heading = isMirrorDestination
+    ? 'Switch mirror without losing work?'
+    : 'Leave this page without losing work?';
+  const currentLabel = isMirrorDestination ? 'Current Mirror' : 'Current Draft';
+  const nextCardLabel = isMirrorDestination ? 'Next Mirror' : 'Destination';
+  const discardLabel = isMirrorDestination ? 'Discard And Switch' : 'Discard And Leave';
+  const saveLabel = isMirrorDestination ? 'Save And Switch' : 'Save And Leave';
+
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4 backdrop-blur-md">
       <div className="w-full max-w-lg overflow-hidden rounded-2xl border border-border bg-surface shadow-2xl">
         <div className="border-b border-border bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_45%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0))] px-6 py-5">
@@ -39,12 +50,10 @@ export const UnsavedMirrorChangesModal = ({
               <p className="mb-1 text-xs font-semibold uppercase tracking-[0.22em] text-amber-300/80">
                 Unsaved Changes
               </p>
-              <h2 className="text-xl font-semibold text-foreground">
-                Switch mirror without losing work?
-              </h2>
+              <h2 className="text-xl font-semibold text-foreground">{heading}</h2>
               <p className="mt-2 text-sm leading-6 text-muted">
                 You have pending layout changes{currentMirror ? ` on ${currentMirror.name}` : ''}.
-                Choose what should happen before opening {nextMirror.name}.
+                Choose what should happen before opening {nextLabel}.
               </p>
             </div>
           </div>
@@ -52,7 +61,7 @@ export const UnsavedMirrorChangesModal = ({
           <div className="grid gap-3 rounded-2xl border border-border/80 bg-background/35 p-4 sm:grid-cols-2">
             <div className="rounded-xl border border-border/80 bg-surface/80 p-3">
               <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
-                Current Mirror
+                {currentLabel}
               </p>
               <p className="mt-2 truncate text-sm font-medium text-foreground">
                 {currentMirror?.name ?? 'Current mirror'}
@@ -60,9 +69,9 @@ export const UnsavedMirrorChangesModal = ({
             </div>
             <div className="rounded-xl border border-primary/25 bg-primary/8 p-3">
               <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary/80">
-                Next Mirror
+                {nextCardLabel}
               </p>
-              <p className="mt-2 truncate text-sm font-medium text-foreground">{nextMirror.name}</p>
+              <p className="mt-2 truncate text-sm font-medium text-foreground">{nextLabel}</p>
             </div>
           </div>
         </div>
@@ -82,7 +91,7 @@ export const UnsavedMirrorChangesModal = ({
             disabled={isSaving}
             className="rounded-md border border-border px-4 py-2 text-sm text-foreground transition-all hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            Discard And Switch
+            {discardLabel}
           </button>
           <button
             type="button"
@@ -90,10 +99,11 @@ export const UnsavedMirrorChangesModal = ({
             disabled={isSaving}
             className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-on-primary transition-all hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {isSaving ? 'Saving...' : 'Save And Switch'}
+            {isSaving ? 'Saving...' : saveLabel}
           </button>
         </div>
       </div>
     </div>,
     document.body,
   );
+};

--- a/frontend/src/components/mirrors/UnsavedMirrorChangesModal.tsx
+++ b/frontend/src/components/mirrors/UnsavedMirrorChangesModal.tsx
@@ -1,0 +1,99 @@
+import { createPortal } from 'react-dom';
+import type { MirrorDto } from '../../api/types/mirror';
+
+interface UnsavedMirrorChangesModalProps {
+  currentMirror: MirrorDto | null;
+  nextMirror: MirrorDto;
+  isSaving: boolean;
+  onClose: () => void;
+  onDiscard: () => void;
+  onSave: () => void;
+}
+
+export const UnsavedMirrorChangesModal = ({
+  currentMirror,
+  nextMirror,
+  isSaving,
+  onClose,
+  onDiscard,
+  onSave,
+}: UnsavedMirrorChangesModalProps) =>
+  createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4 backdrop-blur-md">
+      <div className="w-full max-w-lg overflow-hidden rounded-2xl border border-border bg-surface shadow-2xl">
+        <div className="border-b border-border bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_45%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0))] px-6 py-5">
+          <div className="mb-4 flex items-start gap-4">
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-amber-400/30 bg-amber-500/12 text-amber-300">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path
+                  d="M12 8v5m0 3.5h.01M10.29 3.86l-7.5 13A2 2 0 0 0 4.5 20h15a2 2 0 0 0 1.71-3.14l-7.5-13a2 2 0 0 0-3.42 0Z"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+
+            <div className="min-w-0 flex-1">
+              <p className="mb-1 text-xs font-semibold uppercase tracking-[0.22em] text-amber-300/80">
+                Unsaved Changes
+              </p>
+              <h2 className="text-xl font-semibold text-foreground">
+                Switch mirror without losing work?
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                You have pending layout changes{currentMirror ? ` on ${currentMirror.name}` : ''}.
+                Choose what should happen before opening {nextMirror.name}.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-3 rounded-2xl border border-border/80 bg-background/35 p-4 sm:grid-cols-2">
+            <div className="rounded-xl border border-border/80 bg-surface/80 p-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
+                Current Mirror
+              </p>
+              <p className="mt-2 truncate text-sm font-medium text-foreground">
+                {currentMirror?.name ?? 'Current mirror'}
+              </p>
+            </div>
+            <div className="rounded-xl border border-primary/25 bg-primary/8 p-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary/80">
+                Next Mirror
+              </p>
+              <p className="mt-2 truncate text-sm font-medium text-foreground">{nextMirror.name}</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 px-6 py-5 sm:flex-row sm:items-center sm:justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSaving}
+            className="rounded-md border border-border px-4 py-2 text-sm text-muted transition-all hover:bg-overlay hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Stay Here
+          </button>
+          <button
+            type="button"
+            onClick={onDiscard}
+            disabled={isSaving}
+            className="rounded-md border border-border px-4 py-2 text-sm text-foreground transition-all hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Discard And Switch
+          </button>
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={isSaving}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-on-primary transition-all hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSaving ? 'Saving...' : 'Save And Switch'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );

--- a/frontend/src/hooks/useMirrorDraft.ts
+++ b/frontend/src/hooks/useMirrorDraft.ts
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { AnyWidgetConfig, MirrorDto } from '../api/types/mirror';
+import type { WidgetType } from '../components/layout/dashboard/widgetSidebar/types.ts';
+import { widgetRegistry } from '../components/widgets/widgetRegistry';
+import { createMirrorWidgetDraft } from '../utils/createMirrorWidgetDraft';
+import { buildMirrorWidgetMutationPlan } from '../utils/mirrorWidgetMutationPlan';
+import { findFirstFreeCell } from '../utils/widgetPlacement';
+import { updateMirrorWidgetConfigDraft } from '../utils/updateMirrorWidgetConfigDraft';
+
+export function useMirrorDraft(activeMirror: MirrorDto | null) {
+  const [localMirror, setLocalMirror] = useState<MirrorDto | null>(null);
+  const [editingWidgetIds, setEditingWidgetIds] = useState<string[]>([]);
+
+  const snapshotRef = useRef<MirrorDto | null>(null);
+  const localMirrorRef = useRef<MirrorDto | null>(null);
+
+  const displayedMirror = localMirror ?? activeMirror;
+  const hasOpenWidgetEditor = editingWidgetIds.length > 0;
+
+  const initializeDraft = useCallback((mirror: MirrorDto) => {
+    snapshotRef.current = structuredClone(mirror);
+    setLocalMirror(structuredClone(mirror));
+    setEditingWidgetIds([]);
+  }, []);
+
+  const syncDraftFromMirror = useCallback((mirror: MirrorDto) => {
+    snapshotRef.current = structuredClone(mirror);
+    localMirrorRef.current = structuredClone(mirror);
+    setLocalMirror(structuredClone(mirror));
+  }, []);
+
+  const clearDraft = useCallback(() => {
+    setEditingWidgetIds([]);
+    setLocalMirror(null);
+    localMirrorRef.current = null;
+    snapshotRef.current = null;
+  }, []);
+
+  const hasUnsavedChanges = useCallback(() => {
+    const mutationPlan = buildMirrorWidgetMutationPlan(snapshotRef.current, localMirrorRef.current);
+    return mutationPlan.hasChanges;
+  }, []);
+
+  const handleAddWidget = useCallback((widgetType: WidgetType) => {
+    const tempId = `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    setLocalMirror((previous) => {
+      if (!previous) {
+        return previous;
+      }
+
+      const definition = widgetRegistry.find((widget) => widget.id === widgetType);
+      if (!definition) {
+        return previous;
+      }
+
+      const placed = previous.widgets.map((widget) => {
+        const widgetDefinition = widgetRegistry.find((entry) => entry.id === widget.type);
+        return {
+          x: widget.x,
+          y: widget.y,
+          cols: widgetDefinition?.cols ?? 2,
+          rows: widgetDefinition?.rows ?? 2,
+        };
+      });
+
+      const position = findFirstFreeCell(
+        placed,
+        definition.cols,
+        definition.rows,
+        previous.widthCm,
+        previous.heightCm,
+      );
+
+      return {
+        ...previous,
+        widgets: [
+          ...previous.widgets,
+          createMirrorWidgetDraft(tempId, widgetType, position.x, position.y),
+        ],
+      };
+    });
+  }, []);
+
+  const handleRemoveWidget = useCallback((widgetId: string) => {
+    setLocalMirror((previous) => {
+      if (!previous) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        widgets: previous.widgets.filter((widget) => widget.id !== widgetId),
+      };
+    });
+  }, []);
+
+  const handleMoveWidget = useCallback((widgetId: string, x: number, y: number) => {
+    setLocalMirror((previous) => {
+      if (!previous) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        widgets: previous.widgets.map((widget) =>
+          widget.id === widgetId ? { ...widget, x, y } : widget,
+        ),
+      };
+    });
+  }, []);
+
+  const handleUpdateWidgetConfig = useCallback((widgetId: string, config: AnyWidgetConfig) => {
+    setLocalMirror((previous) => {
+      if (!previous) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        widgets: previous.widgets.map((widget) =>
+          widget.id === widgetId ? updateMirrorWidgetConfigDraft(widget, config) : widget,
+        ),
+      };
+    });
+  }, []);
+
+  const handleWidgetEditorStateChange = useCallback((widgetId: string, isEditing: boolean) => {
+    setEditingWidgetIds((previous) => {
+      if (isEditing) {
+        return previous.includes(widgetId) ? previous : [...previous, widgetId];
+      }
+
+      return previous.filter((currentWidgetId) => currentWidgetId !== widgetId);
+    });
+  }, []);
+
+  useEffect(() => {
+    localMirrorRef.current = localMirror;
+  }, [localMirror]);
+
+  useEffect(() => {
+    if (!displayedMirror) {
+      setEditingWidgetIds([]);
+      return;
+    }
+
+    const widgetIds = new Set(displayedMirror.widgets.map((widget) => widget.id));
+    setEditingWidgetIds((previous) => previous.filter((widgetId) => widgetIds.has(widgetId)));
+  }, [displayedMirror]);
+
+  return {
+    displayedMirror,
+    snapshotRef,
+    localMirrorRef,
+    hasOpenWidgetEditor,
+    hasDraftSession: snapshotRef.current !== null,
+    initializeDraft,
+    syncDraftFromMirror,
+    clearDraft,
+    hasUnsavedChanges,
+    handleAddWidget,
+    handleRemoveWidget,
+    handleMoveWidget,
+    handleUpdateWidgetConfig,
+    handleWidgetEditorStateChange,
+  };
+}

--- a/frontend/src/hooks/useMirrorEditor.ts
+++ b/frontend/src/hooks/useMirrorEditor.ts
@@ -1,0 +1,184 @@
+import { useCallback, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useGetMyMirrorsQuery } from '../api/endpoints/mirror';
+import { useGetCurrentUserQuery } from '../api/endpoints/user';
+import type { MirrorDto } from '../api/types/mirror';
+import { useActiveMirror } from '../context/ActiveMirrorContext';
+import { useEditModeContext } from '../context/EditModeContext';
+import { useMirrorDraft } from './useMirrorDraft';
+import { useMirrorPersistence } from './useMirrorPersistence';
+import { useMirrorSessionLifecycle } from './useMirrorSessionLifecycle';
+import { useMirrorSwitchGuard } from './useMirrorSwitchGuard';
+
+export function useMirrorEditor() {
+  const { isEditMode, enterEditMode, saveEditMode, discardEditMode } = useEditModeContext();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { activeMirrorId, setActiveMirrorId } = useActiveMirror();
+
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [editingMirror, setEditingMirror] = useState<MirrorDto | null>(null);
+  const [deletingMirror, setDeletingMirror] = useState<MirrorDto | null>(null);
+  const { data: mirrors = [], refetch: refetchMirrors } = useGetMyMirrorsQuery();
+  const { data: currentUser } = useGetCurrentUserQuery();
+
+  const activeMirror = mirrors.find((mirror) => mirror.id === activeMirrorId) ?? null;
+  const mirrorLimit = currentUser?.isPremium ? 10 : 3;
+  const canAddMirror = mirrors.length < mirrorLimit;
+
+  const {
+    displayedMirror,
+    snapshotRef,
+    localMirrorRef,
+    hasOpenWidgetEditor,
+    hasDraftSession,
+    initializeDraft,
+    syncDraftFromMirror,
+    clearDraft,
+    hasUnsavedChanges,
+    handleAddWidget,
+    handleRemoveWidget,
+    handleMoveWidget,
+    handleUpdateWidgetConfig,
+    handleWidgetEditorStateChange,
+  } = useMirrorDraft(activeMirror);
+
+  const {
+    autosaveStatus,
+    isAutosaveEnabled,
+    isPersistenceBusy,
+    resetPersistenceState,
+    flushMirrorChanges,
+    toggleAutosavePreference,
+  } = useMirrorPersistence({
+    isEditMode,
+    activeMirrorId,
+    activeMirror,
+    hasOpenWidgetEditor,
+    snapshotRef,
+    localMirrorRef,
+    clearDraft,
+    syncDraftFromMirror,
+    saveEditMode,
+    refetchMirrors,
+  });
+
+  const resetEditorState = useCallback(() => {
+    resetPersistenceState();
+    clearDraft();
+  }, [clearDraft, resetPersistenceState]);
+
+  const startEditSession = useCallback(
+    (mirror: MirrorDto) => {
+      resetPersistenceState();
+      initializeDraft(mirror);
+      enterEditMode();
+    },
+    [enterEditMode, initializeDraft, resetPersistenceState],
+  );
+
+  useMirrorSessionLifecycle({
+    location,
+    navigate,
+    isEditMode,
+    activeMirrorId,
+    activeMirror,
+    setActiveMirrorId,
+    hasDraftSession,
+    hasUnsavedChanges,
+    startEditSession,
+    resetEditorState,
+    discardEditMode,
+  });
+
+  const {
+    pendingMirrorSwitch,
+    isResolvingMirrorSwitch,
+    handleSelectMirror,
+    handleClosePendingMirrorSwitch,
+    handleDiscardAndSwitch,
+    handleSaveAndSwitch,
+  } = useMirrorSwitchGuard({
+    activeMirrorId,
+    mirrors,
+    isEditMode,
+    hasUnsavedChanges,
+    isBusy: isPersistenceBusy,
+    setActiveMirrorId,
+    startEditSession,
+    resetEditorState,
+    saveBeforeSwitch: () =>
+      flushMirrorChanges({
+        exitEditMode: false,
+        trigger: 'manual',
+        syncDraftWithServer: false,
+      }),
+  });
+
+  const handleEnterEditMode = useCallback(() => {
+    if (!activeMirror) {
+      return;
+    }
+
+    startEditSession(activeMirror);
+  }, [activeMirror, startEditSession]);
+
+  const handleSave = useCallback(async () => {
+    await flushMirrorChanges({ exitEditMode: true, trigger: 'manual' });
+  }, [flushMirrorChanges]);
+
+  const handleDiscard = useCallback(() => {
+    resetEditorState();
+    discardEditMode();
+  }, [discardEditMode, resetEditorState]);
+
+  const handleToggleAutosave = useCallback(() => {
+    resetPersistenceState();
+    toggleAutosavePreference();
+  }, [resetPersistenceState, toggleAutosavePreference]);
+
+  const handleDeleted = useCallback(() => {
+    if (deletingMirror?.id === activeMirrorId) {
+      setActiveMirrorId(null);
+    }
+
+    setDeletingMirror(null);
+  }, [activeMirrorId, deletingMirror?.id, setActiveMirrorId]);
+
+  return {
+    isEditMode,
+    activeMirrorId,
+    activeMirror,
+    displayedMirror,
+    showCreateModal,
+    editingMirror,
+    deletingMirror,
+    pendingMirrorSwitch,
+    isResolvingMirrorSwitch,
+    canAddMirror,
+    isAutosaveEnabled,
+    autosaveStatus,
+    openCreateModal: () => setShowCreateModal(true),
+    closeCreateModal: () => setShowCreateModal(false),
+    openEditMirrorModal: setEditingMirror,
+    openDeleteMirrorModal: setDeletingMirror,
+    closeEditMirrorModal: () => setEditingMirror(null),
+    closeDeleteMirrorModal: () => setDeletingMirror(null),
+    handleDeleted,
+    handleSelectMirror,
+    handleClosePendingMirrorSwitch,
+    handleDiscardAndSwitch,
+    handleSaveAndSwitch,
+    handleEnterEditMode,
+    handleSave,
+    handleDiscard,
+    handleToggleAutosave,
+    handleAddWidget,
+    handleRemoveWidget,
+    handleMoveWidget,
+    handleUpdateWidgetConfig,
+    handleWidgetEditorStateChange,
+    previewMirror: activeMirrorId ? () => navigate(`/preview/${activeMirrorId}`) : undefined,
+    canAddWidget: Boolean(activeMirrorId),
+  };
+}

--- a/frontend/src/hooks/useMirrorEditor.ts
+++ b/frontend/src/hooks/useMirrorEditor.ts
@@ -7,6 +7,7 @@ import { useActiveMirror } from '../context/ActiveMirrorContext';
 import { useEditModeContext } from '../context/EditModeContext';
 import { useMirrorDraft } from './useMirrorDraft';
 import { useMirrorPersistence } from './useMirrorPersistence';
+import { useMirrorRouteGuard } from './useMirrorRouteGuard';
 import { useMirrorSessionLifecycle } from './useMirrorSessionLifecycle';
 import { useMirrorSwitchGuard } from './useMirrorSwitchGuard';
 
@@ -115,6 +116,21 @@ export function useMirrorEditor() {
       }),
   });
 
+  const {
+    pendingRouteLabel,
+    isResolvingRouteChange,
+    handleClosePendingRoute,
+    handleDiscardAndNavigate,
+    handleSaveAndNavigate,
+  } = useMirrorRouteGuard({
+    isEditMode,
+    hasUnsavedChanges,
+    isBusy: isPersistenceBusy,
+    resetEditorState,
+    discardEditMode,
+    saveBeforeNavigate: () => flushMirrorChanges({ exitEditMode: true, trigger: 'manual' }),
+  });
+
   const handleEnterEditMode = useCallback(() => {
     if (!activeMirror) {
       return;
@@ -154,7 +170,9 @@ export function useMirrorEditor() {
     editingMirror,
     deletingMirror,
     pendingMirrorSwitch,
+    pendingRouteLabel,
     isResolvingMirrorSwitch,
+    isResolvingRouteChange,
     canAddMirror,
     isAutosaveEnabled,
     autosaveStatus,
@@ -169,6 +187,9 @@ export function useMirrorEditor() {
     handleClosePendingMirrorSwitch,
     handleDiscardAndSwitch,
     handleSaveAndSwitch,
+    handleClosePendingRoute,
+    handleDiscardAndNavigate,
+    handleSaveAndNavigate,
     handleEnterEditMode,
     handleSave,
     handleDiscard,

--- a/frontend/src/hooks/useMirrorPersistence.ts
+++ b/frontend/src/hooks/useMirrorPersistence.ts
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useAddWidgetMutation,
+  useMoveWidgetMutation,
+  useRemoveWidgetMutation,
+  useUpdateWidgetConfigMutation,
+} from '../api/endpoints/mirror';
+import { useMirrorAutosavePreference } from './useMirrorAutosavePreference';
+import { buildMirrorWidgetMutationPlan } from '../utils/mirrorWidgetMutationPlan';
+import type { MirrorDto } from '../api/types/mirror';
+
+const AUTOSAVE_INTERVAL_MS = 15_000;
+const AUTOSAVE_STATUS_RESET_MS = 2_000;
+
+export type AutosaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+interface UseMirrorPersistenceOptions {
+  isEditMode: boolean;
+  activeMirrorId: string | null;
+  activeMirror: MirrorDto | null;
+  hasOpenWidgetEditor: boolean;
+  snapshotRef: React.RefObject<MirrorDto | null>;
+  localMirrorRef: React.RefObject<MirrorDto | null>;
+  clearDraft: () => void;
+  syncDraftFromMirror: (mirror: MirrorDto) => void;
+  saveEditMode: () => void;
+  refetchMirrors: () => Promise<unknown>;
+}
+
+export function useMirrorPersistence({
+  isEditMode,
+  activeMirrorId,
+  activeMirror,
+  hasOpenWidgetEditor,
+  snapshotRef,
+  localMirrorRef,
+  clearDraft,
+  syncDraftFromMirror,
+  saveEditMode,
+  refetchMirrors,
+}: UseMirrorPersistenceOptions) {
+  const [autosaveStatus, setAutosaveStatus] = useState<AutosaveStatus>('idle');
+
+  const saveInFlightRef = useRef(false);
+  const pendingAutosaveSyncMirrorIdRef = useRef<string | null>(null);
+  const autosaveStatusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { isAutosaveEnabled, toggleAutosave } = useMirrorAutosavePreference();
+
+  const [addWidget] = useAddWidgetMutation();
+  const [moveWidget] = useMoveWidgetMutation();
+  const [removeWidget] = useRemoveWidgetMutation();
+  const [updateWidgetConfig] = useUpdateWidgetConfigMutation();
+
+  const clearAutosaveStatusTimer = useCallback(() => {
+    if (autosaveStatusTimeoutRef.current) {
+      clearTimeout(autosaveStatusTimeoutRef.current);
+      autosaveStatusTimeoutRef.current = null;
+    }
+  }, []);
+
+  const updateAutosaveStatus = useCallback(
+    (nextStatus: AutosaveStatus) => {
+      clearAutosaveStatusTimer();
+      setAutosaveStatus(nextStatus);
+
+      if (nextStatus === 'saved' || nextStatus === 'error') {
+        autosaveStatusTimeoutRef.current = setTimeout(() => {
+          setAutosaveStatus('idle');
+          autosaveStatusTimeoutRef.current = null;
+        }, AUTOSAVE_STATUS_RESET_MS);
+      }
+    },
+    [clearAutosaveStatusTimer],
+  );
+
+  const resetPersistenceState = useCallback(() => {
+    clearAutosaveStatusTimer();
+    updateAutosaveStatus('idle');
+    pendingAutosaveSyncMirrorIdRef.current = null;
+    saveInFlightRef.current = false;
+  }, [clearAutosaveStatusTimer, updateAutosaveStatus]);
+
+  const applyMutationPlanSequentially = useCallback(
+    async (mirrorId: string, mutationPlan: ReturnType<typeof buildMirrorWidgetMutationPlan>) => {
+      for (const widgetId of mutationPlan.removedWidgetIds) {
+        await removeWidget({ mirrorId, widgetId }).unwrap();
+      }
+
+      for (const widget of mutationPlan.addedWidgets) {
+        await addWidget({ mirrorId, body: widget }).unwrap();
+      }
+
+      for (const { widgetId, x, y } of mutationPlan.movedWidgets) {
+        await moveWidget({ mirrorId, widgetId, body: { x, y } }).unwrap();
+      }
+
+      for (const { widgetId, config } of mutationPlan.updatedWidgetConfigs) {
+        await updateWidgetConfig({ mirrorId, widgetId, body: { config } }).unwrap();
+      }
+    },
+    [addWidget, moveWidget, removeWidget, updateWidgetConfig],
+  );
+
+  const flushMirrorChanges = useCallback(
+    async ({
+      exitEditMode,
+      trigger,
+      syncDraftWithServer = !exitEditMode,
+    }: {
+      exitEditMode: boolean;
+      trigger: 'manual' | 'autosave';
+      syncDraftWithServer?: boolean;
+    }) => {
+      if (saveInFlightRef.current || pendingAutosaveSyncMirrorIdRef.current) {
+        return false;
+      }
+
+      const snapshot = snapshotRef.current;
+      const draft = localMirrorRef.current;
+
+      if (!snapshot || !draft) {
+        if (exitEditMode) {
+          saveEditMode();
+          clearDraft();
+        }
+
+        return true;
+      }
+
+      const mutationPlan = buildMirrorWidgetMutationPlan(snapshot, draft);
+
+      if (!mutationPlan.hasChanges) {
+        if (exitEditMode) {
+          saveEditMode();
+          clearDraft();
+        }
+
+        return true;
+      }
+
+      saveInFlightRef.current = true;
+      updateAutosaveStatus('saving');
+
+      if (exitEditMode) {
+        saveEditMode();
+      }
+
+      try {
+        await applyMutationPlanSequentially(draft.id, mutationPlan);
+
+        if (exitEditMode) {
+          await refetchMirrors();
+          clearDraft();
+          resetPersistenceState();
+          updateAutosaveStatus('saved');
+          return true;
+        }
+
+        if (!syncDraftWithServer) {
+          await refetchMirrors();
+          clearDraft();
+          resetPersistenceState();
+          updateAutosaveStatus('saved');
+          return true;
+        }
+
+        pendingAutosaveSyncMirrorIdRef.current = draft.id;
+        await refetchMirrors();
+        return true;
+      } catch {
+        saveInFlightRef.current = false;
+        pendingAutosaveSyncMirrorIdRef.current = null;
+
+        if (trigger === 'autosave') {
+          updateAutosaveStatus('error');
+        }
+
+        return false;
+      }
+    },
+    [
+      applyMutationPlanSequentially,
+      clearDraft,
+      localMirrorRef,
+      refetchMirrors,
+      resetPersistenceState,
+      saveEditMode,
+      snapshotRef,
+      updateAutosaveStatus,
+    ],
+  );
+
+  useEffect(() => {
+    return () => {
+      clearAutosaveStatusTimer();
+    };
+  }, [clearAutosaveStatusTimer]);
+
+  useEffect(() => {
+    const pendingMirrorId = pendingAutosaveSyncMirrorIdRef.current;
+
+    if (!pendingMirrorId || !activeMirror || activeMirror.id !== pendingMirrorId) {
+      return;
+    }
+
+    syncDraftFromMirror(activeMirror);
+    pendingAutosaveSyncMirrorIdRef.current = null;
+    saveInFlightRef.current = false;
+    updateAutosaveStatus('saved');
+  }, [activeMirror, syncDraftFromMirror, updateAutosaveStatus]);
+
+  useEffect(() => {
+    if (!isEditMode || !activeMirrorId || !isAutosaveEnabled) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      const mutationPlan = buildMirrorWidgetMutationPlan(
+        snapshotRef.current,
+        localMirrorRef.current,
+      );
+
+      if (
+        hasOpenWidgetEditor ||
+        !mutationPlan.hasChanges ||
+        saveInFlightRef.current ||
+        pendingAutosaveSyncMirrorIdRef.current
+      ) {
+        return;
+      }
+
+      void flushMirrorChanges({ exitEditMode: false, trigger: 'autosave' });
+    }, AUTOSAVE_INTERVAL_MS);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [
+    activeMirrorId,
+    flushMirrorChanges,
+    hasOpenWidgetEditor,
+    isAutosaveEnabled,
+    isEditMode,
+    localMirrorRef,
+    snapshotRef,
+  ]);
+
+  return {
+    autosaveStatus,
+    isAutosaveEnabled,
+    isPersistenceBusy: saveInFlightRef.current || pendingAutosaveSyncMirrorIdRef.current !== null,
+    resetPersistenceState,
+    flushMirrorChanges,
+    toggleAutosavePreference: toggleAutosave,
+  };
+}

--- a/frontend/src/hooks/useMirrorRouteGuard.ts
+++ b/frontend/src/hooks/useMirrorRouteGuard.ts
@@ -1,0 +1,117 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useBlocker } from 'react-router-dom';
+
+interface UseMirrorRouteGuardOptions {
+  isEditMode: boolean;
+  hasUnsavedChanges: () => boolean;
+  isBusy: boolean;
+  resetEditorState: () => void;
+  discardEditMode: () => void;
+  saveBeforeNavigate: () => Promise<boolean>;
+}
+
+function getNavigationLabel(pathname: string) {
+  if (pathname.startsWith('/preview/')) {
+    return 'Preview';
+  }
+
+  if (pathname === '/widgets') {
+    return 'Widgets';
+  }
+
+  if (pathname === '/friends') {
+    return 'Friends';
+  }
+
+  if (pathname === '/style-guide') {
+    return 'Style Guide';
+  }
+
+  if (pathname === '/') {
+    return 'Mirrors';
+  }
+
+  return 'the next page';
+}
+
+export function useMirrorRouteGuard({
+  isEditMode,
+  hasUnsavedChanges,
+  isBusy,
+  resetEditorState,
+  discardEditMode,
+  saveBeforeNavigate,
+}: UseMirrorRouteGuardOptions) {
+  const [isResolvingRouteChange, setIsResolvingRouteChange] = useState(false);
+
+  const blocker = useBlocker(
+    useCallback(
+      ({ currentLocation, nextLocation }) => {
+        if (!isEditMode || !hasUnsavedChanges()) {
+          return false;
+        }
+
+        return (
+          currentLocation.pathname !== nextLocation.pathname ||
+          currentLocation.search !== nextLocation.search ||
+          currentLocation.hash !== nextLocation.hash
+        );
+      },
+      [hasUnsavedChanges, isEditMode],
+    ),
+  );
+
+  const pendingRouteLabel = useMemo(() => {
+    if (blocker.state !== 'blocked' || !blocker.location) {
+      return null;
+    }
+
+    return getNavigationLabel(blocker.location.pathname);
+  }, [blocker.location, blocker.state]);
+
+  const handleClosePendingRoute = useCallback(() => {
+    if (blocker.state !== 'blocked' || isResolvingRouteChange || isBusy) {
+      return;
+    }
+
+    blocker.reset();
+  }, [blocker, isBusy, isResolvingRouteChange]);
+
+  const handleDiscardAndNavigate = useCallback(() => {
+    if (blocker.state !== 'blocked' || isResolvingRouteChange || isBusy) {
+      return;
+    }
+
+    resetEditorState();
+    discardEditMode();
+    blocker.proceed();
+  }, [blocker, discardEditMode, isBusy, isResolvingRouteChange, resetEditorState]);
+
+  const handleSaveAndNavigate = useCallback(async () => {
+    if (blocker.state !== 'blocked' || isResolvingRouteChange || isBusy) {
+      return;
+    }
+
+    setIsResolvingRouteChange(true);
+
+    try {
+      const didSave = await saveBeforeNavigate();
+
+      if (!didSave) {
+        return;
+      }
+
+      blocker.proceed();
+    } finally {
+      setIsResolvingRouteChange(false);
+    }
+  }, [blocker, isBusy, isResolvingRouteChange, saveBeforeNavigate]);
+
+  return {
+    pendingRouteLabel,
+    isResolvingRouteChange,
+    handleClosePendingRoute,
+    handleDiscardAndNavigate,
+    handleSaveAndNavigate,
+  };
+}

--- a/frontend/src/hooks/useMirrorRouteGuard.ts
+++ b/frontend/src/hooks/useMirrorRouteGuard.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useBlocker } from 'react-router-dom';
+import { useBlocker, type BlockerFunction } from 'react-router-dom';
 
 interface UseMirrorRouteGuardOptions {
   isEditMode: boolean;
@@ -44,22 +44,22 @@ export function useMirrorRouteGuard({
 }: UseMirrorRouteGuardOptions) {
   const [isResolvingRouteChange, setIsResolvingRouteChange] = useState(false);
 
-  const blocker = useBlocker(
-    useCallback(
-      ({ currentLocation, nextLocation }) => {
-        if (!isEditMode || !hasUnsavedChanges()) {
-          return false;
-        }
+  const shouldBlockRouteChange = useCallback<BlockerFunction>(
+    ({ currentLocation, nextLocation }) => {
+      if (!isEditMode || !hasUnsavedChanges()) {
+        return false;
+      }
 
-        return (
-          currentLocation.pathname !== nextLocation.pathname ||
-          currentLocation.search !== nextLocation.search ||
-          currentLocation.hash !== nextLocation.hash
-        );
-      },
-      [hasUnsavedChanges, isEditMode],
-    ),
+      return (
+        currentLocation.pathname !== nextLocation.pathname ||
+        currentLocation.search !== nextLocation.search ||
+        currentLocation.hash !== nextLocation.hash
+      );
+    },
+    [hasUnsavedChanges, isEditMode],
   );
+
+  const blocker = useBlocker(shouldBlockRouteChange);
 
   const pendingRouteLabel = useMemo(() => {
     if (blocker.state !== 'blocked' || !blocker.location) {

--- a/frontend/src/hooks/useMirrorSessionLifecycle.ts
+++ b/frontend/src/hooks/useMirrorSessionLifecycle.ts
@@ -1,0 +1,88 @@
+import { useEffect } from 'react';
+import type { Location, NavigateFunction } from 'react-router-dom';
+import type { MirrorDto } from '../api/types/mirror';
+
+const EDIT_MODE_STORAGE_KEY = 'editMode';
+
+interface UseMirrorSessionLifecycleOptions {
+  location: Location;
+  navigate: NavigateFunction;
+  isEditMode: boolean;
+  activeMirrorId: string | null;
+  activeMirror: MirrorDto | null;
+  setActiveMirrorId: (id: string | null) => void;
+  hasDraftSession: boolean;
+  hasUnsavedChanges: () => boolean;
+  startEditSession: (mirror: MirrorDto) => void;
+  resetEditorState: () => void;
+  discardEditMode: () => void;
+}
+
+export function useMirrorSessionLifecycle({
+  location,
+  navigate,
+  isEditMode,
+  activeMirrorId,
+  activeMirror,
+  setActiveMirrorId,
+  hasDraftSession,
+  hasUnsavedChanges,
+  startEditSession,
+  resetEditorState,
+  discardEditMode,
+}: UseMirrorSessionLifecycleOptions) {
+  useEffect(() => {
+    const stateId = (location.state as { activeMirrorId?: string } | null)?.activeMirrorId;
+    if (stateId) {
+      setActiveMirrorId(stateId);
+    }
+  }, [location.state, setActiveMirrorId]);
+
+  useEffect(() => {
+    if (isEditMode && activeMirror && !hasDraftSession) {
+      startEditSession(activeMirror);
+    }
+  }, [activeMirror, hasDraftSession, isEditMode, startEditSession]);
+
+  useEffect(() => {
+    const state = location.state as { activeMirrorId?: string; enterEditMode?: boolean } | null;
+
+    if (isEditMode && !activeMirrorId && !state?.activeMirrorId && !state?.enterEditMode) {
+      resetEditorState();
+      discardEditMode();
+    }
+  }, [activeMirrorId, discardEditMode, isEditMode, location.state, resetEditorState]);
+
+  useEffect(() => {
+    const state = location.state as { enterEditMode?: boolean } | null;
+
+    if (state?.enterEditMode && activeMirror && !isEditMode) {
+      startEditSession(activeMirror);
+      navigate('/', { replace: true, state: { activeMirrorId } });
+    }
+  }, [activeMirror, activeMirrorId, isEditMode, location.state, navigate, startEditSession]);
+
+  useEffect(() => {
+    if (!isEditMode) {
+      return;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      window.localStorage.setItem(EDIT_MODE_STORAGE_KEY, 'false');
+
+      if (!hasUnsavedChanges()) {
+        return;
+      }
+
+      event.preventDefault();
+      event.returnValue = '';
+      return '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [hasUnsavedChanges, isEditMode]);
+}

--- a/frontend/src/hooks/useMirrorSwitchGuard.ts
+++ b/frontend/src/hooks/useMirrorSwitchGuard.ts
@@ -1,0 +1,129 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { MirrorDto } from '../api/types/mirror';
+
+interface UseMirrorSwitchGuardOptions {
+  activeMirrorId: string | null;
+  mirrors: MirrorDto[];
+  isEditMode: boolean;
+  hasUnsavedChanges: () => boolean;
+  isBusy: boolean;
+  setActiveMirrorId: (id: string | null) => void;
+  startEditSession: (mirror: MirrorDto) => void;
+  resetEditorState: () => void;
+  saveBeforeSwitch: () => Promise<boolean>;
+}
+
+export function useMirrorSwitchGuard({
+  activeMirrorId,
+  mirrors,
+  isEditMode,
+  hasUnsavedChanges,
+  isBusy,
+  setActiveMirrorId,
+  startEditSession,
+  resetEditorState,
+  saveBeforeSwitch,
+}: UseMirrorSwitchGuardOptions) {
+  const [pendingMirrorSwitchId, setPendingMirrorSwitchId] = useState<string | null>(null);
+  const [isResolvingMirrorSwitch, setIsResolvingMirrorSwitch] = useState(false);
+
+  const pendingMirrorSwitch = useMemo(
+    () => mirrors.find((mirror) => mirror.id === pendingMirrorSwitchId) ?? null,
+    [mirrors, pendingMirrorSwitchId],
+  );
+
+  const completeMirrorSwitch = useCallback(
+    (nextMirror: MirrorDto) => {
+      resetEditorState();
+      setPendingMirrorSwitchId(null);
+      setActiveMirrorId(nextMirror.id);
+      startEditSession(nextMirror);
+    },
+    [resetEditorState, setActiveMirrorId, startEditSession],
+  );
+
+  const handleSelectMirror = useCallback(
+    async (id: string) => {
+      if (id === activeMirrorId) {
+        return;
+      }
+
+      const nextMirror = mirrors.find((mirror) => mirror.id === id) ?? null;
+
+      if (!nextMirror) {
+        setActiveMirrorId(id);
+        return;
+      }
+
+      if (!isEditMode) {
+        setActiveMirrorId(id);
+        return;
+      }
+
+      if (isBusy) {
+        return;
+      }
+
+      if (hasUnsavedChanges()) {
+        setPendingMirrorSwitchId(id);
+        return;
+      }
+
+      completeMirrorSwitch(nextMirror);
+    },
+    [
+      activeMirrorId,
+      completeMirrorSwitch,
+      hasUnsavedChanges,
+      isBusy,
+      isEditMode,
+      mirrors,
+      setActiveMirrorId,
+    ],
+  );
+
+  const handleClosePendingMirrorSwitch = useCallback(() => {
+    if (isResolvingMirrorSwitch) {
+      return;
+    }
+
+    setPendingMirrorSwitchId(null);
+  }, [isResolvingMirrorSwitch]);
+
+  const handleDiscardAndSwitch = useCallback(() => {
+    if (!pendingMirrorSwitch || isResolvingMirrorSwitch) {
+      return;
+    }
+
+    completeMirrorSwitch(pendingMirrorSwitch);
+  }, [completeMirrorSwitch, isResolvingMirrorSwitch, pendingMirrorSwitch]);
+
+  const handleSaveAndSwitch = useCallback(async () => {
+    if (!pendingMirrorSwitch || isResolvingMirrorSwitch) {
+      return;
+    }
+
+    setIsResolvingMirrorSwitch(true);
+
+    try {
+      const didSave = await saveBeforeSwitch();
+
+      if (!didSave) {
+        return;
+      }
+
+      completeMirrorSwitch(pendingMirrorSwitch);
+    } finally {
+      setIsResolvingMirrorSwitch(false);
+    }
+  }, [completeMirrorSwitch, isResolvingMirrorSwitch, pendingMirrorSwitch, saveBeforeSwitch]);
+
+  return {
+    pendingMirrorSwitch,
+    isResolvingMirrorSwitch,
+    handleSelectMirror,
+    handleClosePendingMirrorSwitch,
+    handleDiscardAndSwitch,
+    handleSaveAndSwitch,
+  };
+}

--- a/frontend/src/pages/Mirrors.tsx
+++ b/frontend/src/pages/Mirrors.tsx
@@ -16,7 +16,9 @@ function MirrorContent() {
     editingMirror,
     deletingMirror,
     pendingMirrorSwitch,
+    pendingRouteLabel,
     isResolvingMirrorSwitch,
+    isResolvingRouteChange,
     canAddMirror,
     isAutosaveEnabled,
     autosaveStatus,
@@ -31,6 +33,9 @@ function MirrorContent() {
     handleClosePendingMirrorSwitch,
     handleDiscardAndSwitch,
     handleSaveAndSwitch,
+    handleClosePendingRoute,
+    handleDiscardAndNavigate,
+    handleSaveAndNavigate,
     handleEnterEditMode,
     handleSave,
     handleDiscard,
@@ -63,7 +68,9 @@ function MirrorContent() {
         deletingMirror={deletingMirror}
         activeMirror={activeMirror}
         pendingMirrorSwitch={pendingMirrorSwitch}
+        pendingRouteLabel={pendingRouteLabel}
         isResolvingMirrorSwitch={isResolvingMirrorSwitch}
+        isResolvingRouteChange={isResolvingRouteChange}
         onCloseCreateModal={closeCreateModal}
         onCloseEditModal={closeEditMirrorModal}
         onCloseDeleteModal={closeDeleteMirrorModal}
@@ -71,6 +78,9 @@ function MirrorContent() {
         onClosePendingMirrorSwitch={handleClosePendingMirrorSwitch}
         onDiscardAndSwitch={handleDiscardAndSwitch}
         onSaveAndSwitch={handleSaveAndSwitch}
+        onClosePendingRoute={handleClosePendingRoute}
+        onDiscardAndNavigate={handleDiscardAndNavigate}
+        onSaveAndNavigate={handleSaveAndNavigate}
       />
 
       <div className="flex flex-1 overflow-hidden">

--- a/frontend/src/pages/Mirrors.tsx
+++ b/frontend/src/pages/Mirrors.tsx
@@ -1,449 +1,80 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
 import { WidgetSidebar } from '../components/layout/dashboard/WidgetSidebar';
 import { EditModeToggle } from '../components/layout/editMode/EditModeToggle';
-import { EditModeProvider, useEditModeContext } from '../context/EditModeContext';
-import { useActiveMirror } from '../context/ActiveMirrorContext';
+import { MirrorEditorModals } from '../components/mirrors/MirrorEditorModals';
 import { MirrorSubNav } from '../components/layout/navigation/sub-navigation/MirrorSubNav';
-import { CreateMirrorModal } from '../components/mirrors/CreateMirrorModal';
-import { EditMirrorModal } from '../components/mirrors/EditMirrorModal';
-import { DeleteMirrorModal } from '../components/mirrors/DeleteMirrorModal';
-import { updateMirrorWidgetConfigDraft } from '../utils/updateMirrorWidgetConfigDraft';
-import {
-  useGetMyMirrorsQuery,
-  useAddWidgetMutation,
-  useMoveWidgetMutation,
-  useRemoveWidgetMutation,
-  useUpdateWidgetConfigMutation,
-} from '../api/endpoints/mirror';
+import { EditModeProvider } from '../context/EditModeContext';
 import { MirrorCanvas } from '../components/mirrors/MirrorCanvas';
-import type { AnyWidgetConfig, MirrorDto } from '../api/types/mirror';
-import type { WidgetType } from '../components/layout/dashboard/widgetSidebar/types.ts';
-import { widgetRegistry } from '../components/widgets/widgetRegistry';
-import { findFirstFreeCell } from '../utils/widgetPlacement';
-import { useGetCurrentUserQuery } from '../api/endpoints/user';
-import { useMirrorAutosavePreference } from '../hooks/useMirrorAutosavePreference';
-import { buildMirrorWidgetMutationPlan } from '../utils/mirrorWidgetMutationPlan';
-import { createMirrorWidgetDraft } from '../utils/createMirrorWidgetDraft';
-
-const AUTOSAVE_INTERVAL_MS = 15_000;
-const AUTOSAVE_STATUS_RESET_MS = 2_000;
-
-type AutosaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+import { useMirrorEditor } from '../hooks/useMirrorEditor';
 
 function MirrorContent() {
-  const { isEditMode, enterEditMode, saveEditMode, discardEditMode } = useEditModeContext();
-  const navigate = useNavigate();
-  const location = useLocation();
-  const { activeMirrorId, setActiveMirrorId } = useActiveMirror();
-
-  const [showCreateModal, setShowCreateModal] = useState(false);
-  const [editingMirror, setEditingMirror] = useState<MirrorDto | null>(null);
-  const [deletingMirror, setDeletingMirror] = useState<MirrorDto | null>(null);
-  const [localMirror, setLocalMirror] = useState<MirrorDto | null>(null);
-  const [editingWidgetIds, setEditingWidgetIds] = useState<string[]>([]);
-  const [autosaveStatus, setAutosaveStatus] = useState<AutosaveStatus>('idle');
-
-  const snapshotRef = useRef<MirrorDto | null>(null);
-  const localMirrorRef = useRef<MirrorDto | null>(null);
-  const saveInFlightRef = useRef(false);
-  const pendingAutosaveSyncMirrorIdRef = useRef<string | null>(null);
-  const autosaveStatusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const { isAutosaveEnabled, toggleAutosave } = useMirrorAutosavePreference();
-
-  const { data: mirrors = [], refetch: refetchMirrors } = useGetMyMirrorsQuery();
-  const { data: currentUser } = useGetCurrentUserQuery();
-  const mirrorLimit = currentUser?.isPremium ? 10 : 3;
-  const canAddMirror = mirrors.length < mirrorLimit;
-
-  const [addWidget] = useAddWidgetMutation();
-  const [moveWidget] = useMoveWidgetMutation();
-  const [removeWidget] = useRemoveWidgetMutation();
-  const [updateWidgetConfig] = useUpdateWidgetConfigMutation();
-
-  const activeMirror = mirrors.find((mirror) => mirror.id === activeMirrorId) ?? null;
-  const displayedMirror = localMirror ?? activeMirror;
-  const hasOpenWidgetEditor = editingWidgetIds.length > 0;
-
-  useEffect(() => {
-    localMirrorRef.current = localMirror;
-  }, [localMirror]);
-
-  useEffect(() => {
-    if (!displayedMirror) {
-      setEditingWidgetIds([]);
-      return;
-    }
-
-    const widgetIds = new Set(displayedMirror.widgets.map((widget) => widget.id));
-    setEditingWidgetIds((previous) => previous.filter((widgetId) => widgetIds.has(widgetId)));
-  }, [displayedMirror]);
-
-  const clearAutosaveStatusTimer = useCallback(() => {
-    if (autosaveStatusTimeoutRef.current) {
-      clearTimeout(autosaveStatusTimeoutRef.current);
-      autosaveStatusTimeoutRef.current = null;
-    }
-  }, []);
-
-  const updateAutosaveStatus = useCallback(
-    (nextStatus: AutosaveStatus) => {
-      clearAutosaveStatusTimer();
-      setAutosaveStatus(nextStatus);
-
-      if (nextStatus === 'saved' || nextStatus === 'error') {
-        autosaveStatusTimeoutRef.current = setTimeout(() => {
-          setAutosaveStatus('idle');
-          autosaveStatusTimeoutRef.current = null;
-        }, AUTOSAVE_STATUS_RESET_MS);
-      }
-    },
-    [clearAutosaveStatusTimer],
-  );
-
-  useEffect(() => {
-    return () => {
-      clearAutosaveStatusTimer();
-    };
-  }, [clearAutosaveStatusTimer]);
-
-  useEffect(() => {
-    const stateId = (location.state as { activeMirrorId?: string } | null)?.activeMirrorId;
-    if (stateId) {
-      setActiveMirrorId(stateId);
-    }
-  }, [location.state, setActiveMirrorId]);
-
-  useEffect(() => {
-    if (isEditMode && activeMirror && snapshotRef.current === null) {
-      const snapshot = structuredClone(activeMirror);
-      snapshotRef.current = snapshot;
-      setLocalMirror(structuredClone(activeMirror));
-    }
-  }, [isEditMode, activeMirror]);
-
-  useEffect(() => {
-    const pendingMirrorId = pendingAutosaveSyncMirrorIdRef.current;
-
-    if (!pendingMirrorId || !activeMirror || activeMirror.id !== pendingMirrorId) {
-      return;
-    }
-
-    const freshMirror = structuredClone(activeMirror);
-    snapshotRef.current = freshMirror;
-    localMirrorRef.current = structuredClone(activeMirror);
-    setLocalMirror(structuredClone(activeMirror));
-
-    pendingAutosaveSyncMirrorIdRef.current = null;
-    saveInFlightRef.current = false;
-    updateAutosaveStatus('saved');
-  }, [activeMirror, updateAutosaveStatus]);
-
-  const startEditSession = useCallback(
-    (mirror: MirrorDto) => {
-      const snapshot = structuredClone(mirror);
-      snapshotRef.current = snapshot;
-      setLocalMirror(structuredClone(mirror));
-      updateAutosaveStatus('idle');
-      enterEditMode();
-    },
-    [enterEditMode, updateAutosaveStatus],
-  );
-
-  useEffect(() => {
-    const state = location.state as { enterEditMode?: boolean } | null;
-    if (state?.enterEditMode && activeMirror && !isEditMode) {
-      startEditSession(activeMirror);
-      navigate('/', { replace: true, state: { activeMirrorId } });
-    }
-  }, [activeMirror, activeMirrorId, isEditMode, location.state, navigate, startEditSession]);
-
-  const handleEnterEditMode = useCallback(() => {
-    if (!activeMirror) return;
-    startEditSession(activeMirror);
-  }, [activeMirror, startEditSession]);
-
-  const handleAddWidget = useCallback((widgetType: WidgetType) => {
-    const tempId = `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-
-    setLocalMirror((previous) => {
-      if (!previous) return previous;
-
-      const definition = widgetRegistry.find((widget) => widget.id === widgetType);
-      if (!definition) return previous;
-
-      const placed = previous.widgets.map((widget) => {
-        const widgetDefinition = widgetRegistry.find((entry) => entry.id === widget.type);
-        return {
-          x: widget.x,
-          y: widget.y,
-          cols: widgetDefinition?.cols ?? 2,
-          rows: widgetDefinition?.rows ?? 2,
-        };
-      });
-
-      const position = findFirstFreeCell(
-        placed,
-        definition.cols,
-        definition.rows,
-        previous.widthCm,
-        previous.heightCm,
-      );
-
-      const nextWidget = createMirrorWidgetDraft(tempId, widgetType, position.x, position.y);
-
-      return {
-        ...previous,
-        widgets: [...previous.widgets, nextWidget],
-      };
-    });
-  }, []);
-
-  const handleRemoveWidget = useCallback((widgetId: string) => {
-    setLocalMirror((previous) => {
-      if (!previous) return previous;
-      return {
-        ...previous,
-        widgets: previous.widgets.filter((widget) => widget.id !== widgetId),
-      };
-    });
-  }, []);
-
-  const handleMoveWidget = useCallback((widgetId: string, x: number, y: number) => {
-    setLocalMirror((previous) => {
-      if (!previous) return previous;
-      return {
-        ...previous,
-        widgets: previous.widgets.map((widget) =>
-          widget.id === widgetId ? { ...widget, x, y } : widget,
-        ),
-      };
-    });
-  }, []);
-
-  const handleUpdateWidgetConfig = useCallback((widgetId: string, config: AnyWidgetConfig) => {
-    setLocalMirror((previous) => {
-      if (!previous) return previous;
-
-      return {
-        ...previous,
-        widgets: previous.widgets.map((widget) =>
-          widget.id === widgetId ? updateMirrorWidgetConfigDraft(widget, config) : widget,
-        ),
-      };
-    });
-  }, []);
-
-  const handleWidgetEditorStateChange = useCallback((widgetId: string, isEditing: boolean) => {
-    setEditingWidgetIds((previous) => {
-      if (isEditing) {
-        return previous.includes(widgetId) ? previous : [...previous, widgetId];
-      }
-
-      return previous.filter((currentWidgetId) => currentWidgetId !== widgetId);
-    });
-  }, []);
-
-  const applyMutationPlanSequentially = useCallback(
-    async (mirrorId: string, mutationPlan: ReturnType<typeof buildMirrorWidgetMutationPlan>) => {
-      for (const widgetId of mutationPlan.removedWidgetIds) {
-        await removeWidget({ mirrorId, widgetId }).unwrap();
-      }
-
-      for (const widget of mutationPlan.addedWidgets) {
-        await addWidget({ mirrorId, body: widget }).unwrap();
-      }
-
-      for (const { widgetId, x, y } of mutationPlan.movedWidgets) {
-        await moveWidget({ mirrorId, widgetId, body: { x, y } }).unwrap();
-      }
-
-      for (const { widgetId, config } of mutationPlan.updatedWidgetConfigs) {
-        await updateWidgetConfig({
-          mirrorId,
-          widgetId,
-          body: { config },
-        }).unwrap();
-      }
-    },
-    [addWidget, moveWidget, removeWidget, updateWidgetConfig],
-  );
-
-  const flushMirrorChanges = useCallback(
-    async ({
-      exitEditMode,
-      trigger,
-    }: {
-      exitEditMode: boolean;
-      trigger: 'manual' | 'autosave';
-    }) => {
-      if (saveInFlightRef.current || pendingAutosaveSyncMirrorIdRef.current) {
-        return false;
-      }
-
-      const snapshot = snapshotRef.current;
-      const draft = localMirrorRef.current;
-
-      if (!snapshot || !draft) {
-        if (exitEditMode) {
-          saveEditMode();
-          setLocalMirror(null);
-          localMirrorRef.current = null;
-          snapshotRef.current = null;
-        }
-
-        return true;
-      }
-
-      const mutationPlan = buildMirrorWidgetMutationPlan(snapshot, draft);
-
-      if (!mutationPlan.hasChanges) {
-        if (exitEditMode) {
-          saveEditMode();
-          setLocalMirror(null);
-          localMirrorRef.current = null;
-          snapshotRef.current = null;
-        }
-
-        return true;
-      }
-
-      saveInFlightRef.current = true;
-
-      if (trigger === 'manual') {
-        updateAutosaveStatus('saving');
-      } else if (trigger === 'autosave') {
-        updateAutosaveStatus('saving');
-      }
-
-      if (exitEditMode) {
-        saveEditMode();
-      }
-
-      const mirrorId = draft.id;
-
-      try {
-        await applyMutationPlanSequentially(mirrorId, mutationPlan);
-
-        if (exitEditMode) {
-          await refetchMirrors();
-          setLocalMirror(null);
-          localMirrorRef.current = null;
-          snapshotRef.current = null;
-          saveInFlightRef.current = false;
-          updateAutosaveStatus('saved');
-          return true;
-        }
-
-        pendingAutosaveSyncMirrorIdRef.current = mirrorId;
-        await refetchMirrors();
-        return true;
-      } catch {
-        saveInFlightRef.current = false;
-        pendingAutosaveSyncMirrorIdRef.current = null;
-
-        if (trigger === 'autosave') {
-          updateAutosaveStatus('error');
-        }
-
-        return false;
-      }
-    },
-    [
-      addWidget,
-      moveWidget,
-      applyMutationPlanSequentially,
-      refetchMirrors,
-      removeWidget,
-      saveEditMode,
-      updateAutosaveStatus,
-      updateWidgetConfig,
-    ],
-  );
-
-  const handleSave = useCallback(async () => {
-    await flushMirrorChanges({ exitEditMode: true, trigger: 'manual' });
-  }, [flushMirrorChanges]);
-
-  const handleDiscard = useCallback(() => {
-    clearAutosaveStatusTimer();
-    updateAutosaveStatus('idle');
-    pendingAutosaveSyncMirrorIdRef.current = null;
-    saveInFlightRef.current = false;
-    setEditingWidgetIds([]);
-    setLocalMirror(null);
-    localMirrorRef.current = null;
-    snapshotRef.current = null;
-    discardEditMode();
-  }, [clearAutosaveStatusTimer, discardEditMode, updateAutosaveStatus]);
-
-  const handleToggleAutosave = useCallback(() => {
-    clearAutosaveStatusTimer();
-    updateAutosaveStatus('idle');
-    toggleAutosave();
-  }, [clearAutosaveStatusTimer, toggleAutosave, updateAutosaveStatus]);
-
-  useEffect(() => {
-    if (!isEditMode || !activeMirrorId || !isAutosaveEnabled) {
-      return;
-    }
-
-    const intervalId = setInterval(() => {
-      const mutationPlan = buildMirrorWidgetMutationPlan(
-        snapshotRef.current,
-        localMirrorRef.current,
-      );
-
-      if (
-        hasOpenWidgetEditor ||
-        !mutationPlan.hasChanges ||
-        saveInFlightRef.current ||
-        pendingAutosaveSyncMirrorIdRef.current
-      ) {
-        return;
-      }
-
-      void flushMirrorChanges({ exitEditMode: false, trigger: 'autosave' });
-    }, AUTOSAVE_INTERVAL_MS);
-
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [activeMirrorId, flushMirrorChanges, hasOpenWidgetEditor, isAutosaveEnabled, isEditMode]);
-
-  const handleDeleted = useCallback(() => {
-    if (deletingMirror?.id === activeMirrorId) setActiveMirrorId(null);
-    setDeletingMirror(null);
-  }, [activeMirrorId, deletingMirror?.id, setActiveMirrorId]);
+  const {
+    isEditMode,
+    activeMirrorId,
+    activeMirror,
+    displayedMirror,
+    showCreateModal,
+    editingMirror,
+    deletingMirror,
+    pendingMirrorSwitch,
+    isResolvingMirrorSwitch,
+    canAddMirror,
+    isAutosaveEnabled,
+    autosaveStatus,
+    openCreateModal,
+    closeCreateModal,
+    openEditMirrorModal,
+    openDeleteMirrorModal,
+    closeEditMirrorModal,
+    closeDeleteMirrorModal,
+    handleDeleted,
+    handleSelectMirror,
+    handleClosePendingMirrorSwitch,
+    handleDiscardAndSwitch,
+    handleSaveAndSwitch,
+    handleEnterEditMode,
+    handleSave,
+    handleDiscard,
+    handleToggleAutosave,
+    handleAddWidget,
+    handleRemoveWidget,
+    handleMoveWidget,
+    handleUpdateWidgetConfig,
+    handleWidgetEditorStateChange,
+    previewMirror,
+    canAddWidget,
+  } = useMirrorEditor();
 
   return (
     <div className="flex flex-col flex-1">
       <MirrorSubNav
         activeMirrorId={activeMirrorId}
-        onSelectMirror={setActiveMirrorId}
-        onAddMirror={() => setShowCreateModal(true)}
-        onEditMirror={setEditingMirror}
-        onDeleteMirror={setDeletingMirror}
+        onSelectMirror={(id) => {
+          void handleSelectMirror(id);
+        }}
+        onAddMirror={openCreateModal}
+        onEditMirror={openEditMirrorModal}
+        onDeleteMirror={openDeleteMirrorModal}
         canAddMirror={canAddMirror}
       />
 
-      {showCreateModal && <CreateMirrorModal onClose={() => setShowCreateModal(false)} />}
-      {editingMirror && (
-        <EditMirrorModal mirror={editingMirror} onClose={() => setEditingMirror(null)} />
-      )}
-      {deletingMirror && (
-        <DeleteMirrorModal
-          mirror={deletingMirror}
-          onClose={() => setDeletingMirror(null)}
-          onDeleted={handleDeleted}
-        />
-      )}
+      <MirrorEditorModals
+        showCreateModal={showCreateModal}
+        editingMirror={editingMirror}
+        deletingMirror={deletingMirror}
+        activeMirror={activeMirror}
+        pendingMirrorSwitch={pendingMirrorSwitch}
+        isResolvingMirrorSwitch={isResolvingMirrorSwitch}
+        onCloseCreateModal={closeCreateModal}
+        onCloseEditModal={closeEditMirrorModal}
+        onCloseDeleteModal={closeDeleteMirrorModal}
+        onDeletedMirror={handleDeleted}
+        onClosePendingMirrorSwitch={handleClosePendingMirrorSwitch}
+        onDiscardAndSwitch={handleDiscardAndSwitch}
+        onSaveAndSwitch={handleSaveAndSwitch}
+      />
 
       <div className="flex flex-1 overflow-hidden">
-        {isEditMode && (
-          <WidgetSidebar onAddWidget={handleAddWidget} canAddWidget={Boolean(activeMirrorId)} />
-        )}
+        {isEditMode && <WidgetSidebar onAddWidget={handleAddWidget} canAddWidget={canAddWidget} />}
 
         <MirrorCanvas
           mirror={displayedMirror}
@@ -458,7 +89,7 @@ function MirrorContent() {
           onEnterEditMode={handleEnterEditMode}
           onSave={handleSave}
           onDiscard={handleDiscard}
-          onPreview={activeMirrorId ? () => navigate(`/preview/${activeMirrorId}`) : undefined}
+          onPreview={previewMirror}
           autosaveEnabled={isAutosaveEnabled}
           autosaveStatus={autosaveStatus}
           onToggleAutosave={handleToggleAutosave}


### PR DESCRIPTION
- Add MirrorEditorModals component to handle create, edit, delete, and unsaved changes modals for mirrors.
- Introduce UnsavedMirrorChangesModal for prompting users about unsaved changes when switching mirrors.
- Create useMirrorDraft hook to manage local mirror state and draft changes.
- Implement useMirrorEditor hook to encapsulate mirror editing logic and state management.
- Add useMirrorPersistence hook for handling autosave functionality and persistence of mirror changes.
- Create useMirrorSessionLifecycle hook to manage the lifecycle of mirror editing sessions.
- Implement useMirrorSwitchGuard hook to handle switching between mirrors with unsaved changes.

## Checklista
* [x] Har du kontrollerat att PR-rubriken är beskrivande och att det är tydligt vilken US som PR kopplas till?
* [x] Har du kontrollerat att filändringarna speglar syftet med PR?
* [x] Har du testat din kod lokalt, om möjligt?
* [x] Har du kört enhets- och integrationstester och att dessa inte failar?
* [ ] Har du skapat nya enhets- eller integrationstester, där det är nödvändigt?
* [x] Har du följt vår kodstandard?
* [ ] Om din kod innehåller migrations, har du testat så att dessa funkar?
* [ ] Har du uppdaterat dokumentation kopplat till PR, om nödvändigt?
